### PR TITLE
[MET-2381] Hotfix: Patches the Offers and Configs not being processed

### DIFF
--- a/SDK/Runtime/BackendOperations.cs
+++ b/SDK/Runtime/BackendOperations.cs
@@ -86,7 +86,7 @@ namespace Metica.Unity
 
                     if (www.result != UnityWebRequest.Result.Success)
                     {
-                        var error = $"Error: {www.error}, status: {www.responseCode}, endpoint:{www.url}";
+                        var error = $"Error: {www.error}, status: {www.responseCode}, endpoint: {www.url}";
                         MeticaLogger.LogError(() => error);
                         callback(SdkResultImpl<RequestResponse<T>>.WithError($"API Error: {error}"));
                     }

--- a/SDK/Runtime/MeticaAPI.cs
+++ b/SDK/Runtime/MeticaAPI.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
-using UnityEngine;
 
 // ReSharper disable all NotAccessedField.Global
 // ReSharper disable file UnusedMember.Local

--- a/SDK/Runtime/OffersManager.cs
+++ b/SDK/Runtime/OffersManager.cs
@@ -72,6 +72,10 @@ namespace Metica.Unity
                     },
                     userProperties, deviceInfo);
             }
+            else
+            {
+                offersCallback(SdkResultImpl<OffersByPlacement>.WithResult(HandleDisplayLimitForReturnedOffers(new OffersByPlacement() { placements = resultOffers })));
+            }
         }
         
         private OffersByPlacement HandleDisplayLimitForReturnedOffers(OffersByPlacement offersByPlacement)

--- a/SDK/Runtime/RemoteConfigManager.cs
+++ b/SDK/Runtime/RemoteConfigManager.cs
@@ -65,12 +65,16 @@ namespace Metica.Unity
                                 resultConfig.Add(pair.Key, pair.Value);
                                 MeticaAPI.RemoteConfigCache.Write(pair.Key, pair.Value, sdkResult.Result.CacheDurationSecs);
                             }
+                            responseCallback(SdkResultImpl<Dictionary<string, object>>.WithResult(resultConfig));
                         }
                     },
                     userProperties, deviceInfo);
             }
+            else
+            {
+                responseCallback(SdkResultImpl<Dictionary<string, object>>.WithResult(resultConfig));
+            }
 
-            responseCallback(SdkResultImpl<Dictionary<string, object>>.WithResult(resultConfig));
         }
     }
 }


### PR DESCRIPTION
In the tested scenario, via `SampleScript` in a test scene, offers and configs were coming through but the passed callback that should process the results wasn't called.
While we work on a better implemetation, this should sort out bugs that were recently reported on offers and configs retrieval. 