### PR TITLE
[MET-2452] Schema compliance, new events in `MeticaAPI` and bug fixes

### DIFF
--- a/SDK/Runtime/BackendOperations.cs
+++ b/SDK/Runtime/BackendOperations.cs
@@ -104,7 +104,7 @@ namespace Metica.Unity
                     else
                     {
                         var responseText = www.downloadHandler.text;
-                        MeticaLogger.LogDebug(() => $"Response raw text:\n{responseText}");
+                        MeticaLogger.LogDebug(() => $"Response raw text:\n{responseText}, endpoint: {www.url}");
 
                         if (string.IsNullOrEmpty(responseText) && (www.responseCode >= 200 || www.responseCode <= 204))
                         {

--- a/SDK/Runtime/EventsLogger.cs
+++ b/SDK/Runtime/EventsLogger.cs
@@ -50,6 +50,27 @@ namespace Metica.Unity
             }
         }
 
+        #region Install & Login Events
+
+        public void LogInstall()
+        {
+            var attributes = new Dictionary<string, object>();
+            AddCommonEventAttributes(attributes, EventTypes.Install);
+            LogEvent(attributes);
+        }
+
+        public void LogLogin(string newCurrentUserId = null)
+        {
+            if(newCurrentUserId !=  null)
+            {
+                MeticaAPI.UserId = newCurrentUserId;
+            }
+            var attributes = new Dictionary<string, object>();
+            AddCommonEventAttributes(attributes, EventTypes.Login);
+            LogEvent(attributes);
+        }
+
+        #endregion Install & Login Events
 
         #region Offer Impression
 

--- a/SDK/Runtime/EventsLogger.cs
+++ b/SDK/Runtime/EventsLogger.cs
@@ -65,7 +65,7 @@ namespace Metica.Unity
         {
             var attributes = new Dictionary<string, object>();
             AddCommonEventAttributes(attributes, EventTypes.OfferImpression);
-            attributes[Constants.AppId] = productId;
+            attributes[Constants.ProductId] = productId;
             LogEvent(attributes);
         }
 

--- a/SDK/Runtime/MeticaAPI.cs
+++ b/SDK/Runtime/MeticaAPI.cs
@@ -403,7 +403,7 @@ namespace Metica.Unity
             if (!File.Exists(filePath))
             {
 #if UNITY_EDITOR
-                WriteJsonSdkInfo();
+                //WriteJsonSdkInfo();
 #else
                 return new SdkInfo { Version = "unknown" };
 #endif
@@ -464,18 +464,14 @@ namespace Metica.Unity
 
             string filePath = Path.Combine(streamingAssetsPath, "sdkInfo.json");
 
-            SdkInfo currentSdkInfo = GetSdkInfo();
  
             string packageVersion = GetPackageVersion("com.metica.unity");
             if (packageVersion != null)
             {
-                if (packageVersion != currentSdkInfo?.Version)
-                {
-                    string jsonData = $"{{\"Version\": \"{packageVersion}\"}}";  // Ensure version is quoted for valid JSON
-                    File.WriteAllText(filePath, jsonData);
-                    Debug.Log($"SDK Info JSON written to: {filePath}");
-                    UnityEditor.AssetDatabase.Refresh(); 
-                }
+                string jsonData = $"{{\"Version\": \"{packageVersion}\"}}";  // Ensure version is quoted for valid JSON
+                File.WriteAllText(filePath, jsonData);
+                Debug.Log($"SDK Info JSON written to: {filePath}");
+                UnityEditor.AssetDatabase.Refresh(); 
             }
             else
             {

--- a/SDK/Runtime/MeticaAPI.cs
+++ b/SDK/Runtime/MeticaAPI.cs
@@ -421,7 +421,7 @@ namespace Metica.Unity
         [UnityEditor.InitializeOnLoadMethod]
         private static void TouchSdkInfo()
         {
-            GetSdkInfo();
+            WriteJsonSdkInfo();
         }
 
         /// <summary>
@@ -464,20 +464,22 @@ namespace Metica.Unity
 
             string filePath = Path.Combine(streamingAssetsPath, "sdkInfo.json");
 
-            if (!File.Exists(filePath))
+            SdkInfo currentSdkInfo = GetSdkInfo();
+ 
+            string packageVersion = GetPackageVersion("com.metica.unity");
+            if (packageVersion != null)
             {
-                string version = GetPackageVersion("com.metica.unity");
-                if (version != null)
+                if (packageVersion != currentSdkInfo?.Version)
                 {
-                    string jsonData = $"{{\"Version\": \"{version}\"}}";  // Ensure version is quoted for valid JSON
+                    string jsonData = $"{{\"Version\": \"{packageVersion}\"}}";  // Ensure version is quoted for valid JSON
                     File.WriteAllText(filePath, jsonData);
                     Debug.Log($"SDK Info JSON written to: {filePath}");
-                    UnityEditor.AssetDatabase.Refresh();
+                    UnityEditor.AssetDatabase.Refresh(); 
                 }
-                else
-                {
-                    Debug.LogError("Package version not found.");
-                }
+            }
+            else
+            {
+                Debug.LogError("Package version not found.");
             }
         }
 

--- a/SDK/Runtime/MeticaAPI.cs
+++ b/SDK/Runtime/MeticaAPI.cs
@@ -146,6 +146,36 @@ namespace Metica.Unity
             }
         }
 
+        #region Install & Login Events
+
+        public static void LogInstall()
+        {
+            if (!checkPreconditions())
+            {
+                return;
+            }
+
+            var logger = ScriptingObjects.GetComponent<EventsLogger>();
+            logger.LogInstall();
+        }
+
+        /// <summary>
+        /// Logs a login event with an optional current user id change.
+        /// </summary>
+        /// <param name="newCurrentUserId"></param>
+        public static void LogLogin(string newCurrentUserId = null)
+        {
+            if (!checkPreconditions())
+            {
+                return;
+            }
+
+            var logger = ScriptingObjects.GetComponent<EventsLogger>();
+            logger.LogLogin(newCurrentUserId);
+        }
+        
+        #endregion Install & Login Events
+
         #region Offer Impression
 
         /// <summary>
@@ -324,12 +354,15 @@ namespace Metica.Unity
 
         #region Custom Event
 
+        // ALIAS (will be promoted to main method call for custom events.
+        public static void LogCustomEvent(string eventType, Dictionary<string, object> userEvent, bool reuseDictionary = false) =>
+            LogUserEvent(eventType, userEvent, reuseDictionary);
         /// <summary>
         /// Logs a custom user event to the Metica API.
         /// </summary>
         /// <remarks>
         /// Do not use this method for logging any of the documented <see href="https://docs.metica.com/integration#core-events">Core Events</see>.
-        /// If you do, an exception will be thrown. Specific methods are available for all of the listed Core event tpyes.
+        /// If you do, a warning will be thrown. Specific methods are available for all of the listed Core event tpyes.
         /// </remarks>
         /// <param name="eventType">The name/type of the event</param>
         /// <param name="userEvent">A dictionary containing the details of the user event. The dictionary should have string keys and object values.</param>

--- a/SDK/Runtime/MeticaAPI.cs
+++ b/SDK/Runtime/MeticaAPI.cs
@@ -32,10 +32,10 @@ namespace Metica.Unity
         public static string SDKVersion
         {
             get {
-                if(_sdkInfoCache == null)
+                if (_sdkInfoCache == null)
                 {
                     _sdkInfoCache = GetSdkInfo();
-                }  
+                }
                 return _sdkInfoCache.Version;
             }
         }
@@ -73,8 +73,9 @@ namespace Metica.Unity
             Initialise(initialUserId, appId, apiKey, SdkConfig.Default(), initCallback);
         }
 
-        public static void Initialise(string initialUserId, string appId, string apiKey, SdkConfig sdkConfig,
-            MeticaSdkDelegate<bool> initCallback)
+        public static void Initialise(SdkConfig sdkConfig, MeticaSdkDelegate<bool> initCallback) => Initialise(sdkConfig.initialUserId, sdkConfig.appId, sdkConfig.apiKey, sdkConfig, initCallback);
+        // TODO: deprecate the following method.
+        public static void Initialise(string initialUserId, string appId, string apiKey, SdkConfig sdkConfig, MeticaSdkDelegate<bool> initCallback)
         {
             UserId = initialUserId;
             AppId = appId;

--- a/SDK/Runtime/Model.cs
+++ b/SDK/Runtime/Model.cs
@@ -10,6 +10,8 @@ namespace Metica.Unity
 {
     internal abstract class EventTypes
     {
+        internal static readonly string Install = "install";
+        internal static readonly string Login = "login";
         internal static readonly string OfferImpression = "impression";
         internal static readonly string OfferInteraction = "interaction";
         internal static readonly string OfferInAppPurchase = "purchase";
@@ -80,6 +82,20 @@ namespace Metica.Unity
     public class OffersByPlacement
     {
         public Dictionary<string, List<Offer>> placements = new Dictionary<string, List<Offer>>();
+        public override string ToString()
+        {
+            System.Text.StringBuilder sb = new System.Text.StringBuilder("OffersByPlacement:");
+            foreach (var placement in placements.Keys)
+            {
+                sb.AppendLine($"Placement: {placement}");
+                foreach (var offer in placements[placement])
+                {
+                    sb.AppendLine($"\tOffer: {offer.offerId}");
+                    sb.AppendLine($"\t\t{offer.iap}");
+                }
+            }
+            return sb.ToString();
+        }
     }
 
     [Serializable]

--- a/SDK/Runtime/OffersCache.cs
+++ b/SDK/Runtime/OffersCache.cs
@@ -35,7 +35,9 @@ namespace Metica.Unity
         public List<Offer>? Read(string placement)
         {
             List<Offer>? value = _cache?.Read(CacheKeyForPlacement(placement));
-            MeticaLogger.LogDebug(() => value == null ? "<b>OFFER CACHE MISS</b>" : "<b>OFFER CACHE HIT</b>");
+            MeticaLogger.LogDebug(() => value == null ?
+                $"<b>{nameof(OffersCache)}: OFFER CACHE MISS (Placement:{placement})</b>"
+                : $"<b>{nameof(OffersCache)}: OFFER CACHE HIT (Placement:{placement})</b>");
             return value;
         }
 

--- a/SDK/Runtime/SdkConfig.cs
+++ b/SDK/Runtime/SdkConfig.cs
@@ -89,6 +89,10 @@ namespace Metica.Unity
         {
             return new SdkConfig()
             {
+                initialUserId = string.Empty,
+                appId = string.Empty,
+                apiKey = string.Empty,
+                // - - - - - - - - - -
                 ingestionEndpoint = "https://api.prod-eu.metica.com",
                 offersEndpoint = "https://api.prod-eu.metica.com",
                 remoteConfigEndpoint = "https://api.prod-eu.metica.com",

--- a/SDK/Runtime/SdkConfig.cs
+++ b/SDK/Runtime/SdkConfig.cs
@@ -6,6 +6,10 @@ namespace Metica.Unity
     [System.Serializable]
     public struct SdkConfig
     {
+        public string apiKey;
+        public string appId;
+        public string initialUserId;
+
         /// <summary>
         /// The full endpoint to the Metica offers endpoint.
         /// </summary>

--- a/SDK/package.json
+++ b/SDK/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.metica.unity",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "displayName": "Metica Unity SDK",
   "description": "Unity components to interface with the Metica offers platform.",
   "unity": "2020.3",

--- a/TestProject/Assets/SampleScript.cs
+++ b/TestProject/Assets/SampleScript.cs
@@ -9,9 +9,6 @@ using UnityEngine.UI;
 
 public class SampleScript : MonoBehaviour
 {
-    [SerializeField] private string _userId = string.Empty;
-    [SerializeField] private string _appId = string.Empty;
-    [SerializeField] private string _apiKey = string.Empty;
     [SerializeField] private SdkConfigProvider _sdkConfiguration;
 
     [SerializeField] Text textElement, _versionText;
@@ -20,9 +17,6 @@ public class SampleScript : MonoBehaviour
 
     void Start()
     {
-        Assert.IsFalse(string.IsNullOrEmpty(_userId));
-        Assert.IsFalse(string.IsNullOrEmpty(_appId));
-        Assert.IsFalse(string.IsNullOrEmpty(_apiKey));
         Assert.IsNotNull(_sdkConfiguration, "Please assign an Sdk Configuration. A new one can be created in Create > Metica > SDK > New SDK Configuration.");
 
         Font legacyFont = (Font)Resources.GetBuiltinResource(typeof(Font), "Arial.ttf");
@@ -33,7 +27,7 @@ public class SampleScript : MonoBehaviour
         // transform.localPosition = new Vector3(0, 0, 0);
         textElement.GetComponent<RectTransform>().localPosition = new Vector3(0, 50, 0);
 
-        MeticaAPI.Initialise(_userId, _appId, _apiKey, _sdkConfiguration.SdkConfig,
+        MeticaAPI.Initialise(_sdkConfiguration.SdkConfig,
             (result => textElement.text = (result.Result ? "Initialised" : "Failed to initialise")));
 
         _getOffersButton.onClick.AddListener(TestGetOffers);
@@ -49,7 +43,8 @@ public class SampleScript : MonoBehaviour
 
     private void TestGetOffers()
     {
-        MeticaAPI.UserId = _userId;
+
+        MeticaAPI.UserId = _sdkConfiguration.SdkConfig.initialUserId;
         MeticaAPI.GetOffers(null, (result) =>
         {
             if (result.Error != null)
@@ -76,7 +71,7 @@ public class SampleScript : MonoBehaviour
 
     private void TestGetConfig()
     {
-        MeticaAPI.UserId = _userId;
+        MeticaAPI.UserId = _sdkConfiguration.SdkConfig.initialUserId;
         // Retrieve all configs
         MeticaAPI.GetConfig(result =>
         {
@@ -94,7 +89,7 @@ public class SampleScript : MonoBehaviour
 
     private void TestGetConfigSpecific()
     {
-        MeticaAPI.UserId = _userId;
+        MeticaAPI.UserId = _sdkConfiguration.SdkConfig.initialUserId;
         // Retrieve config with specific name
         MeticaAPI.GetConfig(result =>
         {
@@ -112,7 +107,7 @@ public class SampleScript : MonoBehaviour
 
     private void TestLogOfferDisplay()
     {
-        MeticaAPI.UserId = _userId;
+        MeticaAPI.UserId = _sdkConfiguration.SdkConfig.initialUserId;
         MeticaAPI.GetOffers(null, (result) =>
         {
             if (result.Error != null)

--- a/TestProject/Assets/Scenes/TestScene.unity
+++ b/TestProject/Assets/Scenes/TestScene.unity
@@ -447,6 +447,54 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 375968512}
   m_CullTransparentMesh: 1
+--- !u!1 &404945941
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 404945943}
+  - component: {fileID: 404945942}
+  m_Layer: 0
+  m_Name: Simulator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &404945942
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 404945941}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ff84af12e78b6ab4aad3af1bb445404f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _userId: testDude
+  _appId: riccard
+  _apiKey: 3fe82f526e2c4e74aae0574713271fe6
+  _sdkConfigProvider: {fileID: 11400000, guid: cfaf76d46fa0dc246a3c95feab851078, type: 2}
+--- !u!4 &404945943
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 404945941}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 420, y: 231, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &471218987
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Main changes

- General schema compliance
- `LogInstall`, `LogLogin` and `LogAdRevenue` events now accessible via `MeticaAPI`, new events are now present in `Models.EventTypes`
- Add `apiKey`, `appId` and `initialUserId` fields to `SdkConfig` and update `MeticaAPI.Initialise` to use `SdkConfig`
- Remove `Moq` dependency
- Add `-WithProductId` methods for offer purchase and interaction events.
- Add debug level printout of backend operations.
- Add `Partial` and `Full` `-UserStateUpdate` event types and API methods
- Fix schema building in `LogOfferInteraction` and `LogOfferPurchase`
- Prevent use of reserved event names in `MeticaAPI.LogUserEvent` method