### PR TITLE
[MET-2466] Mark LogUserAttributes as obsolete

### DIFF
--- a/SDK/Runtime/MeticaAPI.cs
+++ b/SDK/Runtime/MeticaAPI.cs
@@ -296,9 +296,12 @@ namespace Metica.Unity
         [Obsolete("Please use LogFullStateUpdate")]
         public static void LogUserAttributes(Dictionary<string, object> userAttributes) => LogFullStateUpdate(userAttributes);
         /// <summary>
-        /// Log an update of the user attributes.
+        /// Sends a complete snapshot of the user's state to the server, replacing any previously stored data. 
+        /// This method fully resets the user's state on the server and expects all relevant state information to be included in the request.
+        /// Any user attributes that are currently stored in the server with the given userId but are not sent with this update, will be erased.
         /// </summary>
-        /// <param name="userAttributes">A mutable dictionary of user attribute identifiers and their new values.</param>
+        /// <param name="userAttributes">An exhaustive dictionary of user attribute identifiers and their new values.
+        /// Please note that ALL user properties should be passed in the payload.</param>
         public static void LogFullStateUpdate(Dictionary<string, object> userAttributes)
         {
             if (!checkPreconditions())
@@ -311,9 +314,11 @@ namespace Metica.Unity
         }
 
         /// <summary>
-        /// Log a partial update of a user's state (attributes).
+        /// Sends a partial update of the user's state to the server
+        /// modifying or adding only the provided fields while preserving those that are currently stored on the server.
+        /// This method cannot erase existing fields (like `LogFullStateUpdate` does); it can only overwrite values or introduce new ones.
         /// </summary>
-        /// <param name="userAttributes">A mutable dictionary of user attribute identifiers and their new values.</param>
+        /// <param name="userAttributes">A dictionary of user attribute identifiers and their new values.</param>
         public static void LogPartialStateUpdate(Dictionary<string, object> userAttributes)
         {
             if (!checkPreconditions())

--- a/SDK/Runtime/MeticaAPI.cs
+++ b/SDK/Runtime/MeticaAPI.cs
@@ -290,16 +290,16 @@ namespace Metica.Unity
         #region State Update
 
         /// <summary>
-        /// Alias for <see cref="LogUserAttributes"/>.
-        /// TODO: This method will become the one to log a user/player's state update with a full set of values.
+        /// Alias for <see cref="LogFullStateUpdate(Dictionary{string, object})"/>
         /// </summary>
-        /// <param name="userAttributes"></param>
-        public static void LogFullStateUpdate(Dictionary<string, object> userAttributes) => LogUserAttributes(userAttributes);
+        /// <param name="userAttributes">A mutable dictionary of user attribute identifiers and their new values.</param>
+        [Obsolete("Please use LogFullStateUpdate")]
+        public static void LogUserAttributes(Dictionary<string, object> userAttributes) => LogFullStateUpdate(userAttributes);
         /// <summary>
         /// Log an update of the user attributes.
         /// </summary>
         /// <param name="userAttributes">A mutable dictionary of user attribute identifiers and their new values.</param>
-        public static void LogUserAttributes(Dictionary<string, object> userAttributes)
+        public static void LogFullStateUpdate(Dictionary<string, object> userAttributes)
         {
             if (!checkPreconditions())
             {


### PR DESCRIPTION
Small PR with the following:
- Mark LogUserAttributes as obsolete
- Update method summaries