### PR TITLE
[MET-2468] Custom payloads, minor fixes, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The SdkConfig provides the following configuration parameters
 | Property                   | Description                                                                                                                                                                                       |
 |----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `apiKey`					 | Your API key
-| `appId`					 | The application identifier that can be configured in Metica's dashboard
+| `appId`					 | The application identifier accessible from Metica's dashboard.
 | `initialUserId`			 | A string that identifies a user. This can change during the lifetime of your app/game so, for example and depending on your needs, this could be a temporary id like "guest" that later becomes a specific userId, or it can be the current user's id if it's already identified.
 | `offersEndpoint`           | The full endpoint to the Metica offers endpoint.                                                                                                                                                  |
 | `ingestionEndpoint`        | The full endpoint to the Metica ingestion service.                                                                                                                                                |

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Examples:
 MeticaAPI.LogOfferDisplay("<offerId>", "<placementId>");
 MeticaAPI.LogOfferDisplayWithProductId("<productId>");
 MeticaAPI.LogOfferPurchase("<offerId>", "<placementId>", 10.0, "USD");
-MeticaAPI.LogOfferPurchaseWithProductId("<offerId>", "<placementId>", 10.0, "USD");
+MeticaAPI.LogOfferPurchaseWithProductId("<productId>", 10.0, "USD");
 MeticaAPI.LogOfferInteraction("<offerId>", "<placementId>", "click");
 MeticaAPI.LogOfferInteractionWithProductId("<productId>", "click");
 ```
@@ -232,7 +232,7 @@ This method cannot erase existing fields (like `LogFullStateUpdate` does); it ca
 
 ### Custom Payloads
 
-All events support a custom payload that can include any information.  
+All events, except `fullStateUpdate`, `partialStateUpdate` and `CustomEvent`, support a custom payload that can include any information.  
 It's passed as a `Dictionary<string, object>` to the logging methods. To avoid confusion with other fields, it is recommended to pass the parameter by name, i.g. `LogInstall(customPayload: playerExtraParams)` rather than just `LogInstall(playerExtraParams)`.
 
 **Example**  

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ An overview of the role of each DeviceInfo property:
 
 ### Remote Configuration
 
-The `GetConfig` method can be used to obtain the remote configuration.
+The `GetConfig` method can be used to obtain the smart config.
 
 Similar to the `GetOffers` method, the operation is performed asynchronously and the result is delivered through a callback.
 Because the result is specific to each application, the SDK represents it in a generic manner, through a `Dictionary<string, object>` instance.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ The SdkConfig provides the following configuration parameters
 
 | Property                   | Description                                                                                                                                                                                       |
 |----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `apiKey`					 | Your API key
+| `appId`					 | The application identifier that can be configured in Metica's dashboard
+| `initialUserId`			 | A string that identifies a user. This can change during the lifetime of your app/game so, for example and depending on your needs, this could be a temporary id like "guest" that later becomes a specific userId, or it can be the current user's id if it's already identified.
 | `offersEndpoint`           | The full endpoint to the Metica offers endpoint.                                                                                                                                                  |
 | `ingestionEndpoint`        | The full endpoint to the Metica ingestion service.                                                                                                                                                |
 | `remoteConfigEndpoint`     | The full endpoint to the Metica remote config service.                                                                                                                                            |
@@ -149,7 +152,7 @@ An overview of the role of each DeviceInfo property:
 
 ### 3. Remote Configuration
 
-The `GetConfig` method can be used to obtain the remote configuration. The configuration is returnekey
+The `GetConfig` method can be used to obtain the remote configuration.
 
 Similar to the `GetOffers` method, the operation is performed asynchronously and the result is delivered through a callback.
 Because the result is specific to each application, the SDK represents it in a generic manner, through a `Dictionary<string, object>` instance.
@@ -188,7 +191,7 @@ If the `configKeys` argument is `null` or empty, then all the configured keys wi
 
 Note that the server side response for this call is going to be cached according to the cache control directives returned by the server.
 
-For more details regarding the DeviceInfo properties, check the section on [Get Offers](#2-get-offers)
+For more details regarding the `DeviceInfo` properties, check the section on [Get Offers](#2-get-offers)
 
 ### 4. Offer Lifecycle Events
 
@@ -204,24 +207,35 @@ MeticaAPI.LogOfferInteraction("<offerId>", "<placementId>", "click");
 MeticaAPI.LogOfferInteractionWithProductId("<productId>", "click");
 ```
 
-### 5. User Attributes Logging
+### 5. Full State Update
 
-Logs updates to user attributes and custom user events.
+Formerly known as `LogUserAttributes`.
+
+`LogFullStateUpdate` sends a complete snapshot of the user's state to the server, replacing any previously stored data. 
+This method fully resets the user's state on the server and expects all relevant state information to be included in the request.
+Any user attributes that are currently stored in the server with the given userId but are not sent with this update, will be erased.Logs updates to user attributes and custom user events.
 
 ```csharp
 Dictionary<string, object> userAttributes = new Dictionary<string, object> { { "level", 25 }, { "favoriteItem", "shield" } };
-MeticaAPI.LogUserAttributes(userAttributes); 
+MeticaAPI.LogFullStateUpdate(userAttributes); 
 ```
 
-### 6. Custom Event Logging
+### 6. Partial State Update
 
-Logs custom application events. The only required field in the Dictionary is `eventType` which is used by Metica to
-distinguish the
-different types of events.
+`LogPartialStateUpdate` sends a partial update of the user's state to the server
+modifying or adding only the provided fields while preserving those that are currently stored on the server.
+This method cannot erase existing fields (like `LogFullStateUpdate` does); it can only overwrite values or introduce new ones.
+
+### 7. Custom Event Logging
+
+Formerly known as `LogUserEvent`.
+
+`LogCustomEvent` logs custom application events. The only required field in the Dictionary is `eventType` which is used by Metica to
+distinguish the different types of events.
 
 ```csharp
 Dictionary<string, object> customUserEvent = new Dictionary<string, object> { { "eventType", "completed_level" }, { "eventDetails", "level 5" } };
-MeticaAPI.LogUserEvent(userEvent);
+MeticaAPI.LogCustomEvent(userEvent);
 ```
 
 **Note:** The final event that is submitted to the Metica backend is enriched with additional information, so an

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # MeticaAPI Unity SDK Guide
 
+**Disclaimer: please note that the SDK is undergoing some quick changes so, for the time being, this information might contain inaccuracies.**
+
+---
+
 This document provides a quick summary on how to use the MeticaAPI Unity SDK.
 
 Further information about the Metica backend API can be found at
@@ -49,7 +53,7 @@ the '+' button in the top left corner. Select "Add package from git URL" and ent
 
 ## Available SDK Operations
 
-### 1. Initialize the API
+### Initialize the API
 
 Use the `Initialise` method to prepare the MeticaAPI for use. To obtain your API key please contact Metica.  
 ⚠️: This method is obsolete. Please prefer the next call using `SdkConfig`.
@@ -100,7 +104,7 @@ delegate void EventsSubmissionResultDelegate(ISdkResult<Int32> result);
 If the events' submission was successful, then the reported `Int32` result is the number of events submitted.
 Otherwise, in case of error, the field `result.Error` will be non-empty and provide some description of the error.
 
-### 2. Get Offers
+### Get Offers
 
 After initialization, use the `GetOffers` method to obtain offers available for particular placements.
 
@@ -150,7 +154,7 @@ An overview of the role of each DeviceInfo property:
 | appVersion | The game/app version, in [SemVer](https://semver.org/) format                                                                                                                                   | 1.2.3           | 
 | locale     | Locale expressed as a combination of language (ISO 639) and country (ISO 3166), // [JDK 8 standard reference](https://www.oracle.com/java/technologies/javase/jdk8-jre8-suported-locales.html). | en-US           |
 
-### 3. Remote Configuration
+### Remote Configuration
 
 The `GetConfig` method can be used to obtain the remote configuration.
 
@@ -193,7 +197,7 @@ Note that the server side response for this call is going to be cached according
 
 For more details regarding the `DeviceInfo` properties, check the section on [Get Offers](#2-get-offers)
 
-### 4. Offer Lifecycle Events
+### Offer Lifecycle Events
 
 Logs offer related events like offer display, offer purchase, and offer interaction.
 
@@ -207,7 +211,7 @@ MeticaAPI.LogOfferInteraction("<offerId>", "<placementId>", "click");
 MeticaAPI.LogOfferInteractionWithProductId("<productId>", "click");
 ```
 
-### 5. Full State Update
+### Full State Update
 
 Formerly known as `LogUserAttributes`.
 
@@ -220,13 +224,29 @@ Dictionary<string, object> userAttributes = new Dictionary<string, object> { { "
 MeticaAPI.LogFullStateUpdate(userAttributes); 
 ```
 
-### 6. Partial State Update
+### Partial State Update
 
 `LogPartialStateUpdate` sends a partial update of the user's state to the server
 modifying or adding only the provided fields while preserving those that are currently stored on the server.
 This method cannot erase existing fields (like `LogFullStateUpdate` does); it can only overwrite values or introduce new ones.
 
-### 7. Custom Event Logging
+### Custom Payloads
+
+All events support a custom payload that can include any information.  
+It's passed as a `Dictionary<string, object>` to the logging methods. To avoid confusion with other fields, it is recommended to pass the parameter by name, i.g. `LogInstall(customPayload: playerExtraParams)` rather than just `LogInstall(playerExtraParams)`.
+
+**Example**  
+
+```
+Dictionary<string, object> myCustomPayload {
+{ "set", "Intense Stare Magic Mastery" },
+{ "cosmetic", "flamingo shades" },
+};
+LogOfferInteraction(someOfferId, somePlacementId, "selected", myCustomPayload);
+LogOfferPurchase(someOfferId, somePlacementId, 2.49, "GBP", customPayload: myCustomPayload);
+```
+
+### Custom Event Logging
 
 Formerly known as `LogUserEvent`.
 

--- a/SDK/Runtime/EventsLogger.cs
+++ b/SDK/Runtime/EventsLogger.cs
@@ -200,17 +200,20 @@ namespace Metica.Unity
 
         #region Custom Event
 
+        [Obsolete("Please use LogCustomEvent(string eventType, Dictionary<string, object> eventDetails)")]
         public void LogCustomEvent(string eventType, Dictionary<string, object> eventDetails, bool reuseDictionary)
+            => LogCustomEvent(eventType, eventDetails);
+
+        public void LogCustomEvent(string eventType, Dictionary<string, object> eventDetails)
         {
-            if (eventType == null)
+            if (string.IsNullOrEmpty(eventType))
             {
                 MeticaLogger.LogError(() => "The event type must be specified");
                 return;
             }
 
-            var attributes = reuseDictionary ? eventDetails : new Dictionary<string, object>(eventDetails);
-            AddCommonEventAttributes(attributes, eventType);
-            LogEvent(attributes, null);
+            AddCommonEventAttributes(eventDetails, eventType);
+            LogEvent(eventDetails, customPayload: null);
         }
 
         #endregion Custom Event

--- a/SDK/Runtime/EventsLogger.cs
+++ b/SDK/Runtime/EventsLogger.cs
@@ -39,6 +39,18 @@ namespace Metica.Unity
             FlushEvents();
         }
 
+        private void AppendCustomPayload(Dictionary<string, object> attributes, Dictionary<string, object> customAttributes)
+        {
+            if(customAttributes == null || attributes == null)
+            {
+                // TODO : warn!
+                return;
+            }
+            if (!attributes.ContainsKey(Constants.CustomPayload))
+            {
+                attributes.Add(Constants.CustomPayload, customAttributes);
+            }
+        }
         #endregion Unity Lifecycle
 
         private void LogEvent(Dictionary<string, object> eventDetails)

--- a/SDK/Runtime/EventsLogger.cs
+++ b/SDK/Runtime/EventsLogger.cs
@@ -176,24 +176,26 @@ namespace Metica.Unity
         #region State Update
 
         [Obsolete("Please use LogFullStateUpdate")]
-        public void LogUserAttributes(Dictionary<string, object> userAttributes, Dictionary<string, object> customPayload = null)
-            => LogFullStateUpdate(userAttributes, customPayload);
+        public void LogUserAttributes(Dictionary<string, object> userAttributes)
+            => LogFullStateUpdate(userAttributes);
 
-        public void LogFullStateUpdate(Dictionary<string, object> userAttributes, Dictionary<string, object> customPayload = null)
+        public void LogFullStateUpdate(Dictionary<string, object> fullUserAttributes)
         {
             var attributes = new Dictionary<string, object>();
             AddCommonEventAttributes(attributes, EventTypes.FullStateUpdate);
-            attributes[Constants.UserStateAttributes] = userAttributes;
-            LogEvent(attributes, customPayload);
+            attributes[Constants.UserStateAttributes] = fullUserAttributes;
+            LogEvent(attributes);
         }
 
-        // TODO: rename this method to reflect new API naming
-        public void LogPartialUserAttributes(Dictionary<string, object> userAttributes, Dictionary<string, object> customPayload = null)
+        [Obsolete]
+        public void LogPartialUserAttributes(Dictionary<string, object> userAttributes) => LogPartialStateUpdate(userAttributes);
+
+        public void LogPartialStateUpdate(Dictionary<string, object> partialStateAttributes)
         {
             var attributes = new Dictionary<string, object>();
             AddCommonEventAttributes(attributes, EventTypes.PartialStateUpdate);
-            attributes[Constants.UserStateAttributes] = userAttributes;
-            LogEvent(attributes, customPayload);
+            attributes[Constants.UserStateAttributes] = partialStateAttributes;
+            LogEvent(attributes);
         }
 
         #endregion State Update

--- a/SDK/Runtime/EventsLogger.cs
+++ b/SDK/Runtime/EventsLogger.cs
@@ -175,9 +175,11 @@ namespace Metica.Unity
 
         #region State Update
 
-
-        // TODO: rename this method to reflect new API naming
+        [Obsolete("Please use LogFullStateUpdate")]
         public void LogUserAttributes(Dictionary<string, object> userAttributes, Dictionary<string, object> customPayload = null)
+            => LogFullStateUpdate(userAttributes, customPayload);
+
+        public void LogFullStateUpdate(Dictionary<string, object> userAttributes, Dictionary<string, object> customPayload = null)
         {
             var attributes = new Dictionary<string, object>();
             AddCommonEventAttributes(attributes, EventTypes.FullStateUpdate);

--- a/SDK/Runtime/EventsLogger.cs
+++ b/SDK/Runtime/EventsLogger.cs
@@ -212,8 +212,9 @@ namespace Metica.Unity
                 return;
             }
 
-            AddCommonEventAttributes(eventDetails, eventType);
-            LogEvent(eventDetails, customPayload: null);
+            var attributes = new Dictionary<string, object>(eventDetails);
+            AddCommonEventAttributes(attributes, eventType);
+            LogEvent(attributes, customPayload: null);
         }
 
         #endregion Custom Event

--- a/SDK/Runtime/EventsLogger.cs
+++ b/SDK/Runtime/EventsLogger.cs
@@ -51,10 +51,15 @@ namespace Metica.Unity
                 attributes.Add(Constants.CustomPayload, customAttributes);
             }
         }
+
         #endregion Unity Lifecycle
 
-        private void LogEvent(Dictionary<string, object> eventDetails)
+        private void LogEvent(Dictionary<string, object> eventDetails, Dictionary<string, object> customPayload = null)
         {
+            if (customPayload != null && customPayload.Count > 0)
+            {
+                AppendCustomPayload(eventDetails, customPayload);
+            }
             _eventsList.AddFirst(eventDetails);
             if (_eventsList.Count > MeticaAPI.Config.maxPendingLoggedEvents)
             {
@@ -64,14 +69,14 @@ namespace Metica.Unity
 
         #region Install & Login Events
 
-        public void LogInstall()
+        public void LogInstall(Dictionary<string, object> customPayload = null)
         {
             var attributes = new Dictionary<string, object>();
             AddCommonEventAttributes(attributes, EventTypes.Install);
-            LogEvent(attributes);
+            LogEvent(attributes, customPayload);
         }
 
-        public void LogLogin(string newCurrentUserId = null)
+        public void LogLogin(string newCurrentUserId = null, Dictionary<string, object> customPayload = null)
         {
             if(newCurrentUserId !=  null)
             {
@@ -79,34 +84,34 @@ namespace Metica.Unity
             }
             var attributes = new Dictionary<string, object>();
             AddCommonEventAttributes(attributes, EventTypes.Login);
-            LogEvent(attributes);
+            LogEvent(attributes, customPayload);
         }
 
         #endregion Install & Login Events
 
         #region Offer Impression
 
-        public void LogOfferDisplay(string offerId, string placementId)
+        public void LogOfferDisplay(string offerId, string placementId, Dictionary<string, object> customPayload = null)
         {
             var attributes = new Dictionary<string, object>();
             AddCommonEventAttributes(attributes, EventTypes.OfferImpression);
             attributes[Constants.MeticaAttributes] = GetOrCreateMeticaAttributes(offerId, placementId);
-            LogEvent(attributes);
+            LogEvent(attributes, customPayload);
         }
 
-        public void LogOfferDisplayWithProductId(string productId)
+        public void LogOfferDisplayWithProductId(string productId, Dictionary<string, object> customPayload = null)
         {
             var attributes = new Dictionary<string, object>();
             AddCommonEventAttributes(attributes, EventTypes.OfferImpression);
             attributes[Constants.ProductId] = productId;
-            LogEvent(attributes);
+            LogEvent(attributes, customPayload);
         }
 
         #endregion Offer Impression
 
         #region Offer Purchase
 
-        public void LogOfferPurchase(string offerId, string placementId, double amount, string currency)
+        public void LogOfferPurchase(string offerId, string placementId, double amount, string currency, Dictionary<string, object> customPayload = null)
         {
             var attributes = new Dictionary<string, object>();
             AddCommonEventAttributes(attributes, EventTypes.OfferInAppPurchase);
@@ -114,47 +119,47 @@ namespace Metica.Unity
             attributes[Constants.TotalAmount] = amount;
             var meticaAttributes = GetOrCreateMeticaAttributes(offerId, placementId);
             attributes[Constants.MeticaAttributes] = meticaAttributes;
-            LogEvent(attributes);
+            LogEvent(attributes, customPayload);
         }
 
-        public void LogOfferPurchaseWithProductId(string productId, double amount, string currency)
+        public void LogOfferPurchaseWithProductId(string productId, double amount, string currency, Dictionary<string, object> customPayload = null)
         {
             var attributes = new Dictionary <string, object>();
             AddCommonEventAttributes(attributes, EventTypes.OfferInAppPurchase);
             attributes[Constants.CurrencyCode] = currency;
             attributes[Constants.TotalAmount] = amount;
             attributes[Constants.ProductId] = productId;
-            LogEvent(attributes);
+            LogEvent(attributes, customPayload);
         }
 
         #endregion Offer Purchase
 
         #region Offer Interaction
 
-        public void LogOfferInteraction(string offerId, string placementId, string interactionType)
+        public void LogOfferInteraction(string offerId, string placementId, string interactionType, Dictionary<string, object> customPayload = null)
         {
             var attributes = new Dictionary<string, object>();
             AddCommonEventAttributes(attributes, EventTypes.OfferInteraction);
             attributes[Constants.InteractionType] = interactionType;
             var meticaAttributes = GetOrCreateMeticaAttributes(offerId, placementId);
             attributes[Constants.MeticaAttributes] = meticaAttributes;
-            LogEvent(attributes);
+            LogEvent(attributes, customPayload);
         }
 
-        public void LogOfferInteractionWithProductId(string productId, string interactionType)
+        public void LogOfferInteractionWithProductId(string productId, string interactionType, Dictionary<string, object> customPayload = null)
         {
             var attributes = new Dictionary<string, object>();
             AddCommonEventAttributes(attributes, EventTypes.OfferInteraction);
             attributes[Constants.ProductId] = productId;
             attributes[Constants.InteractionType] = interactionType;
-            LogEvent(attributes);
+            LogEvent(attributes, customPayload);
         }
 
         #endregion Offer Interaction
 
         #region Ad Revenue
 
-        public void LogAdRevenue(double amount, string currencyCode, string adPlacement = null, string adPlacementType = null, string adPlacementSource = null)
+        public void LogAdRevenue(double amount, string currencyCode, string adPlacement = null, string adPlacementType = null, string adPlacementSource = null, Dictionary<string, object> customPayload = null)
         {
             var attributes = new Dictionary<string, object>();
             AddCommonEventAttributes(attributes, EventTypes.AdRevenue);
@@ -163,29 +168,30 @@ namespace Metica.Unity
             attributes[Constants.AdPlacement] = adPlacement;
             attributes[Constants.AdPlacementType] = adPlacementType;
             attributes[Constants.AdPlacementSource] = adPlacementSource;
-            LogEvent(attributes);
+            LogEvent(attributes, customPayload);
         }
 
         #endregion Ad Revenue
 
         #region State Update
 
+
         // TODO: rename this method to reflect new API naming
-        public void LogUserAttributes(Dictionary<string, object> userAttributes)
+        public void LogUserAttributes(Dictionary<string, object> userAttributes, Dictionary<string, object> customPayload = null)
         {
             var attributes = new Dictionary<string, object>();
             AddCommonEventAttributes(attributes, EventTypes.FullStateUpdate);
             attributes[Constants.UserStateAttributes] = userAttributes;
-            LogEvent(attributes);
+            LogEvent(attributes, customPayload);
         }
 
         // TODO: rename this method to reflect new API naming
-        public void LogPartialUserAttributes(Dictionary<string, object> userAttributes)
+        public void LogPartialUserAttributes(Dictionary<string, object> userAttributes, Dictionary<string, object> customPayload = null)
         {
             var attributes = new Dictionary<string, object>();
             AddCommonEventAttributes(attributes, EventTypes.PartialStateUpdate);
             attributes[Constants.UserStateAttributes] = userAttributes;
-            LogEvent(attributes);
+            LogEvent(attributes, customPayload);
         }
 
         #endregion State Update
@@ -202,7 +208,7 @@ namespace Metica.Unity
 
             var attributes = reuseDictionary ? eventDetails : new Dictionary<string, object>(eventDetails);
             AddCommonEventAttributes(attributes, eventType);
-            LogEvent(attributes);
+            LogEvent(attributes, null);
         }
 
         #endregion Custom Event

--- a/SDK/Runtime/MeticaAPI.cs
+++ b/SDK/Runtime/MeticaAPI.cs
@@ -148,7 +148,7 @@ namespace Metica.Unity
 
         #region Install & Login Events
 
-        public static void LogInstall()
+        public static void LogInstall(Dictionary<string, object> customPayload = null)
         {
             if (!checkPreconditions())
             {
@@ -156,14 +156,14 @@ namespace Metica.Unity
             }
 
             var logger = ScriptingObjects.GetComponent<EventsLogger>();
-            logger.LogInstall();
+            logger.LogInstall(customPayload);
         }
 
         /// <summary>
         /// Logs a login event with an optional current user id change.
         /// </summary>
         /// <param name="newCurrentUserId"></param>
-        public static void LogLogin(string newCurrentUserId = null)
+        public static void LogLogin(string newCurrentUserId = null, Dictionary<string, object> customPayload = null)
         {
             if (!checkPreconditions())
             {
@@ -171,7 +171,7 @@ namespace Metica.Unity
             }
 
             var logger = ScriptingObjects.GetComponent<EventsLogger>();
-            logger.LogLogin(newCurrentUserId);
+            logger.LogLogin(newCurrentUserId, customPayload);
         }
         
         #endregion Install & Login Events
@@ -183,7 +183,7 @@ namespace Metica.Unity
         /// </summary>
         /// <param name="offerId">The ID of the offer.</param>
         /// <param name="placementId">The ID of the placement where the offer is displayed.</param>
-        public static void LogOfferDisplay(string offerId, string placementId)
+        public static void LogOfferDisplay(string offerId, string placementId, Dictionary<string, object> customPayload = null)
         {
             if (!checkPreconditions())
             {
@@ -191,14 +191,14 @@ namespace Metica.Unity
             }
 
             var logger = ScriptingObjects.GetComponent<EventsLogger>();
-            logger.LogOfferDisplay(offerId, placementId);
+            logger.LogOfferDisplay(offerId, placementId, customPayload);
         }
 
         /// <summary>
         /// Logs an offer impression event using a `productId` value instead of Metica information.
         /// </summary>
         /// <param name="productId">The id of the displayed product.</param>
-        public static void LogOfferDisplayWithProductId(string productId)
+        public static void LogOfferDisplayWithProductId(string productId, Dictionary<string, object> customPayload = null)
         {
             if (!checkPreconditions())
             {
@@ -206,7 +206,7 @@ namespace Metica.Unity
             }
 
             var logger = ScriptingObjects.GetComponent<EventsLogger>();
-            logger.LogOfferDisplayWithProductId(productId);
+            logger.LogOfferDisplayWithProductId(productId, customPayload);
         }
 
        #endregion Offer Impression
@@ -220,7 +220,7 @@ namespace Metica.Unity
         /// <param name="placementId">The ID of the placement where the offer is displayed.</param>
         /// <param name="amount">The amount of the purchase.</param>
         /// <param name="currency">The currency of the purchase.</param>
-        public static void LogOfferPurchase(string offerId, string placementId, double amount, string currency)
+        public static void LogOfferPurchase(string offerId, string placementId, double amount, string currency, Dictionary<string, object> customPayload = null)
         {
             if (!checkPreconditions())
             {
@@ -228,7 +228,7 @@ namespace Metica.Unity
             }
 
             var logger = ScriptingObjects.GetComponent<EventsLogger>();
-            logger.LogOfferPurchase(offerId, placementId, amount, currency);
+            logger.LogOfferPurchase(offerId, placementId, amount, currency, customPayload);
         }
 
         /// <summary>
@@ -237,7 +237,7 @@ namespace Metica.Unity
         /// <param name="productId">The id of the purchased product.</param>
         /// <param name="amount">The spent amount.</param>
         /// <param name="currency">The currency used for this purchase.</param>
-        public static void LogOfferPurchaseWithProductId(string productId, double amount, string currency)
+        public static void LogOfferPurchaseWithProductId(string productId, double amount, string currency, Dictionary<string, object> customPayload = null)
         {
             if (!checkPreconditions())
             {
@@ -245,7 +245,7 @@ namespace Metica.Unity
             }
 
             var logger = ScriptingObjects.GetComponent<EventsLogger>();
-            logger.LogOfferPurchaseWithProductId(productId, amount, currency);
+            logger.LogOfferPurchaseWithProductId(productId, amount, currency, customPayload);
         }
 
         #endregion Offer Purchase
@@ -258,7 +258,7 @@ namespace Metica.Unity
         /// <param name="offerId">The ID of the offer.</param>
         /// <param name="placementId">The ID of the placement where the offer is displayed.</param>
         /// <param name="interactionType">The type of interaction.</param>
-        public static void LogOfferInteraction(string offerId, string placementId, string interactionType)
+        public static void LogOfferInteraction(string offerId, string placementId, string interactionType, Dictionary<string, object> customPayload = null)
         {
             if (!checkPreconditions())
             {
@@ -266,7 +266,7 @@ namespace Metica.Unity
             }
 
             var logger = ScriptingObjects.GetComponent<EventsLogger>();
-            logger.LogOfferInteraction(offerId, placementId, interactionType);
+            logger.LogOfferInteraction(offerId, placementId, interactionType, customPayload);
         }
 
         /// <summary>
@@ -274,7 +274,7 @@ namespace Metica.Unity
         /// </summary>
         /// <param name="productId">The id of the purchased product.</param>
         /// <param name="interactionType">The type of interaction performed by the user.</param>
-        public static void LogOfferInteractionWithProductId(string productId, string interactionType)
+        public static void LogOfferInteractionWithProductId(string productId, string interactionType, Dictionary<string, object> customPayload = null)
         {
             if (!checkPreconditions())
             {
@@ -282,7 +282,7 @@ namespace Metica.Unity
             }
 
             var logger = ScriptingObjects.GetComponent<EventsLogger>();
-            logger.LogOfferInteractionWithProductId(productId, interactionType);
+            logger.LogOfferInteractionWithProductId(productId, interactionType, customPayload);
         }
 
         #endregion Offer Interaction
@@ -294,7 +294,8 @@ namespace Metica.Unity
         /// </summary>
         /// <param name="userAttributes">A mutable dictionary of user attribute identifiers and their new values.</param>
         [Obsolete("Please use LogFullStateUpdate")]
-        public static void LogUserAttributes(Dictionary<string, object> userAttributes) => LogFullStateUpdate(userAttributes);
+        public static void LogUserAttributes(Dictionary<string, object> userAttributes, Dictionary<string, object> customPayload = null)
+            => LogFullStateUpdate(userAttributes, customPayload);
         /// <summary>
         /// Sends a complete snapshot of the user's state to the server, replacing any previously stored data. 
         /// This method fully resets the user's state on the server and expects all relevant state information to be included in the request.
@@ -302,7 +303,7 @@ namespace Metica.Unity
         /// </summary>
         /// <param name="userAttributes">An exhaustive dictionary of user attribute identifiers and their new values.
         /// Please note that ALL user properties should be passed in the payload.</param>
-        public static void LogFullStateUpdate(Dictionary<string, object> userAttributes)
+        public static void LogFullStateUpdate(Dictionary<string, object> userAttributes, Dictionary<string, object> customPayload = null)
         {
             if (!checkPreconditions())
             {
@@ -310,7 +311,7 @@ namespace Metica.Unity
             }
 
             var logger = ScriptingObjects.GetComponent<EventsLogger>();
-            logger.LogUserAttributes(userAttributes);
+            logger.LogUserAttributes(userAttributes, customPayload);
         }
 
         /// <summary>
@@ -319,7 +320,7 @@ namespace Metica.Unity
         /// This method cannot erase existing fields (like `LogFullStateUpdate` does); it can only overwrite values or introduce new ones.
         /// </summary>
         /// <param name="userAttributes">A dictionary of user attribute identifiers and their new values.</param>
-        public static void LogPartialStateUpdate(Dictionary<string, object> userAttributes)
+        public static void LogPartialStateUpdate(Dictionary<string, object> userAttributes, Dictionary<string, object> customPayload = null)
         {
             if (!checkPreconditions())
             {
@@ -327,7 +328,7 @@ namespace Metica.Unity
             }
 
             var logger = ScriptingObjects.GetComponent<EventsLogger>();
-            logger.LogPartialUserAttributes(userAttributes);
+            logger.LogPartialUserAttributes(userAttributes, customPayload);
         }
 
         #endregion State Update
@@ -345,14 +346,14 @@ namespace Metica.Unity
         /// <remarks>
         /// Documentation: <see href="https://docs.metica.com/integration#adrevenue"/>
         /// </remarks>
-        public static void LogAdRevenue(double totalAmount, string currencyCode, string adPlacement = null, string adPlacementType = null, string adPlacementSource = null)
+        public static void LogAdRevenue(double totalAmount, string currencyCode, string adPlacement = null, string adPlacementType = null, string adPlacementSource = null, Dictionary<string, object> customPayload = null)
         {
             if (!checkPreconditions())
             {
                 return;
             }
             var logger = ScriptingObjects.GetComponent<EventsLogger>();
-            logger.LogAdRevenue(totalAmount, currencyCode, adPlacement, adPlacementType, adPlacementSource);
+            logger.LogAdRevenue(totalAmount, currencyCode, adPlacement, adPlacementType, adPlacementSource, customPayload);
         }
 
         #endregion Ad Revenue

--- a/SDK/Runtime/MeticaAPI.cs
+++ b/SDK/Runtime/MeticaAPI.cs
@@ -361,8 +361,8 @@ namespace Metica.Unity
         #region Custom Event
 
         // ALIAS (will be promoted to main method call for custom events.
-        public static void LogCustomEvent(string eventType, Dictionary<string, object> userEvent, bool reuseDictionary = false) =>
-            LogUserEvent(eventType, userEvent, reuseDictionary);
+        public static void LogUserEvent(string eventType, Dictionary<string, object> userEvent, bool reuseDictionary) =>
+            LogCustomEvent(eventType, userEvent);
         /// <summary>
         /// Logs a custom user event to the Metica API.
         /// </summary>
@@ -373,8 +373,7 @@ namespace Metica.Unity
         /// <param name="eventType">The name/type of the event</param>
         /// <param name="userEvent">A dictionary containing the details of the user event. The dictionary should have string keys and object values.</param>
         /// <param name="reuseDictionary">Indicates if the passed dictionary can be modified to add additional Metica-specific attribute. Re-using the dictionary instance in this way can potentially save an allocation.</param>
-        public static void LogUserEvent(string eventType, Dictionary<string, object> userEvent,
-            bool reuseDictionary = false)
+        public static void LogCustomEvent(string eventType, Dictionary<string, object> userEvent)
         {
             if (!checkPreconditions())
             {
@@ -387,7 +386,7 @@ namespace Metica.Unity
             }
 
             var logger = ScriptingObjects.GetComponent<EventsLogger>();
-            logger.LogCustomEvent(eventType, userEvent, reuseDictionary);
+            logger.LogCustomEvent(eventType, userEvent);
         }
 
         #endregion Custom Event

--- a/SDK/Runtime/MeticaAPI.cs
+++ b/SDK/Runtime/MeticaAPI.cs
@@ -311,7 +311,7 @@ namespace Metica.Unity
             }
 
             var logger = ScriptingObjects.GetComponent<EventsLogger>();
-            logger.LogUserAttributes(userAttributes, customPayload);
+            logger.LogFullStateUpdate(userAttributes, customPayload);
         }
 
         /// <summary>

--- a/SDK/Runtime/MeticaAPI.cs
+++ b/SDK/Runtime/MeticaAPI.cs
@@ -294,16 +294,16 @@ namespace Metica.Unity
         /// </summary>
         /// <param name="userAttributes">A mutable dictionary of user attribute identifiers and their new values.</param>
         [Obsolete("Please use LogFullStateUpdate")]
-        public static void LogUserAttributes(Dictionary<string, object> userAttributes, Dictionary<string, object> customPayload = null)
-            => LogFullStateUpdate(userAttributes, customPayload);
+        public static void LogUserAttributes(Dictionary<string, object> userAttributes)
+            => LogFullStateUpdate(userAttributes);
         /// <summary>
         /// Sends a complete snapshot of the user's state to the server, replacing any previously stored data. 
         /// This method fully resets the user's state on the server and expects all relevant state information to be included in the request.
         /// Any user attributes that are currently stored in the server with the given userId but are not sent with this update, will be erased.
         /// </summary>
-        /// <param name="userAttributes">An exhaustive dictionary of user attribute identifiers and their new values.
+        /// <param name="fullUserAttributes">An exhaustive dictionary of user attribute identifiers and their new values.
         /// Please note that ALL user properties should be passed in the payload.</param>
-        public static void LogFullStateUpdate(Dictionary<string, object> userAttributes, Dictionary<string, object> customPayload = null)
+        public static void LogFullStateUpdate(Dictionary<string, object> fullUserAttributes)
         {
             if (!checkPreconditions())
             {
@@ -311,7 +311,7 @@ namespace Metica.Unity
             }
 
             var logger = ScriptingObjects.GetComponent<EventsLogger>();
-            logger.LogFullStateUpdate(userAttributes, customPayload);
+            logger.LogFullStateUpdate(fullUserAttributes);
         }
 
         /// <summary>
@@ -319,8 +319,8 @@ namespace Metica.Unity
         /// modifying or adding only the provided fields while preserving those that are currently stored on the server.
         /// This method cannot erase existing fields (like `LogFullStateUpdate` does); it can only overwrite values or introduce new ones.
         /// </summary>
-        /// <param name="userAttributes">A dictionary of user attribute identifiers and their new values.</param>
-        public static void LogPartialStateUpdate(Dictionary<string, object> userAttributes, Dictionary<string, object> customPayload = null)
+        /// <param name="partialUserAttributes">A dictionary of user attribute identifiers and their new values.</param>
+        public static void LogPartialStateUpdate(Dictionary<string, object> partialUserAttributes)
         {
             if (!checkPreconditions())
             {
@@ -328,7 +328,7 @@ namespace Metica.Unity
             }
 
             var logger = ScriptingObjects.GetComponent<EventsLogger>();
-            logger.LogPartialUserAttributes(userAttributes, customPayload);
+            logger.LogPartialStateUpdate(partialUserAttributes);
         }
 
         #endregion State Update
@@ -360,7 +360,7 @@ namespace Metica.Unity
 
         #region Custom Event
 
-        // ALIAS (will be promoted to main method call for custom events.
+        [Obsolete("Please use LogCustomEvent(string eventType, Dictionary<string, object> userEvent)")]
         public static void LogUserEvent(string eventType, Dictionary<string, object> userEvent, bool reuseDictionary) =>
             LogCustomEvent(eventType, userEvent);
         /// <summary>

--- a/SDK/Runtime/Model.cs
+++ b/SDK/Runtime/Model.cs
@@ -25,6 +25,7 @@ namespace Metica.Unity
     internal abstract class Constants
     {
         internal static readonly string MeticaAttributes = "meticaAttributes";
+        internal static readonly string CustomPayload = "customPayload";
         internal static readonly string CurrencyCode = "currencyCode";
         internal static readonly string TotalAmount = "totalAmount";
         internal static readonly string PlacementId = "placementId";

--- a/SDK/Runtime/OffersCache.cs
+++ b/SDK/Runtime/OffersCache.cs
@@ -36,8 +36,8 @@ namespace Metica.Unity
         {
             List<Offer>? value = _cache?.Read(CacheKeyForPlacement(placement));
             MeticaLogger.LogDebug(() => value == null ?
-                $"<b>{nameof(OffersCache)}: OFFER CACHE MISS (Placement:{placement})</b>"
-                : $"<b>{nameof(OffersCache)}: OFFER CACHE HIT (Placement:{placement})</b>");
+                $"<b>{nameof(OffersCache)}: MISS (Placement:{placement})</b>"
+                : $"<b>{nameof(OffersCache)}: HIT (Placement:{placement})</b>");
             return value;
         }
 

--- a/SDK/Tests/Runtime/EventsLoggerTest.cs
+++ b/SDK/Tests/Runtime/EventsLoggerTest.cs
@@ -207,23 +207,6 @@ namespace MeticaUnitySDK.SDK.Tests.Runtime
             Assert.That(logger.EventsQueue.Count, Is.EqualTo(256));
         }
 
-        //[Test]
-        //public void TestTheReuseOfTheDictionaryInstance()
-        //{
-        //    var logger = new GameObject().AddComponent<EventsLogger>();
-
-        //    var eventType = "test";
-        //    var eventData = new Dictionary<string, object> { { "userId", "rejected" }, { "key2", "value2" } };
-        //    var copyDict = new Dictionary<string, object>(eventData);
-
-        //    logger.LogCustomEvent(eventType, eventData, false);
-
-        //    Assert.That(copyDict, Is.EqualTo(eventData));
-
-        //    logger.LogCustomEvent(eventType, eventData, true);
-        //    Assert.That(copyDict, Is.Not.EqualTo(eventData));
-        //}
-
         private static void assertCommonAttributes(string eventType, Dictionary<string, object> recordedEvent)
         {
             Assert.That(recordedEvent[Constants.EventId], Is.Not.Null);

--- a/SDK/Tests/Runtime/EventsLoggerTest.cs
+++ b/SDK/Tests/Runtime/EventsLoggerTest.cs
@@ -207,22 +207,22 @@ namespace MeticaUnitySDK.SDK.Tests.Runtime
             Assert.That(logger.EventsQueue.Count, Is.EqualTo(256));
         }
 
-        [Test]
-        public void TestTheReuseOfTheDictionaryInstance()
-        {
-            var logger = new GameObject().AddComponent<EventsLogger>();
+        //[Test]
+        //public void TestTheReuseOfTheDictionaryInstance()
+        //{
+        //    var logger = new GameObject().AddComponent<EventsLogger>();
 
-            var eventType = "test";
-            var eventData = new Dictionary<string, object> { { "userId", "rejected" }, { "key2", "value2" } };
-            var copyDict = new Dictionary<string, object>(eventData);
+        //    var eventType = "test";
+        //    var eventData = new Dictionary<string, object> { { "userId", "rejected" }, { "key2", "value2" } };
+        //    var copyDict = new Dictionary<string, object>(eventData);
 
-            logger.LogCustomEvent(eventType, eventData, false);
+        //    logger.LogCustomEvent(eventType, eventData, false);
 
-            Assert.That(copyDict, Is.EqualTo(eventData));
+        //    Assert.That(copyDict, Is.EqualTo(eventData));
 
-            logger.LogCustomEvent(eventType, eventData, true);
-            Assert.That(copyDict, Is.Not.EqualTo(eventData));
-        }
+        //    logger.LogCustomEvent(eventType, eventData, true);
+        //    Assert.That(copyDict, Is.Not.EqualTo(eventData));
+        //}
 
         private static void assertCommonAttributes(string eventType, Dictionary<string, object> recordedEvent)
         {


### PR DESCRIPTION
- Custom payloads as optional parameter for all event logging except custom events
- removed `reuseDictionary` in `LogCustomEvent`
- README update