### PR TITLE
Change public API to be more inline with Applovin's

### DIFF
--- a/Runtime/ADS/Android/AndroidDelegate.cs
+++ b/Runtime/ADS/Android/AndroidDelegate.cs
@@ -25,12 +25,13 @@ internal class AndroidDelegate : PlatformDelegate
 
     public void SetLogEnabled(bool logEnabled)
     {
-        // TODO
+        // TODO tomi
     }
 
-    public void Initialize(string apiKey, string appId, string baseEndpoint)
+    public void Initialize(string apiKey, string appId, string userId, string baseEndpoint)
     {
-        MeticaUnityPluginClass.CallStatic("initialize", apiKey, appId, baseEndpoint);
+        var callback = new InitializeCallbackProxy();
+        MeticaUnityPluginClass.CallStatic("initialize", apiKey, appId, userId, baseEndpoint, callback);
     }
 
     public Task<bool> LoadInterstitialAsync(string userId)
@@ -45,7 +46,7 @@ internal class AndroidDelegate : PlatformDelegate
         callback.AdLoadFailed += InterstitialAdLoadFailed;
 
         Debug.Log($"{TAG} About to call Android loadInterstitial method");
-        MeticaUnityPluginClass.CallStatic("loadInterstitial", userId, callback);
+        MeticaUnityPluginClass.CallStatic("loadInterstitial", callback);
         Debug.Log($"{TAG} Android loadInterstitial method called");
 
         return tcs.Task;
@@ -65,7 +66,7 @@ internal class AndroidDelegate : PlatformDelegate
         callback.AdClicked += (adUnitId) => InterstitialAdClicked?.Invoke(adUnitId);
 
         Debug.Log($"{TAG} About to call Android showInterstitial method");
-        MeticaUnityPluginClass.CallStatic("showInterstitial", "TODO", callback); // TODO passing userId
+        MeticaUnityPluginClass.CallStatic("showInterstitial", callback);
         Debug.Log($"{TAG} Android showInterstitial method called");
 
         return tcs.Task;

--- a/Runtime/ADS/Android/AndroidDelegate.cs
+++ b/Runtime/ADS/Android/AndroidDelegate.cs
@@ -34,7 +34,7 @@ internal class AndroidDelegate : PlatformDelegate
         MeticaUnityPluginClass.CallStatic("initialize", apiKey, appId, userId, baseEndpoint, callback);
     }
 
-    public Task<bool> LoadInterstitialAsync(string userId)
+    public Task<bool> LoadInterstitialAsync()
     {
         Debug.Log($"{TAG} LoadInterstitialAsync called");
 

--- a/Runtime/ADS/Android/AndroidDelegate.cs
+++ b/Runtime/ADS/Android/AndroidDelegate.cs
@@ -52,12 +52,11 @@ internal class AndroidDelegate : PlatformDelegate
         return tcs.Task;
     }
 
-    public Task<bool> ShowInterstitialAsync()
+    public void ShowInterstitial()
     {
-        Debug.Log($"{TAG} ShowInterstitialAsync called");
+        Debug.Log($"{TAG} ShowInterstitial called");
 
-        var tcs = new TaskCompletionSource<bool>();
-        var callback = new ShowCallbackProxy(tcs);
+        var callback = new ShowCallbackProxy();
 
         // Wire up all events
         callback.AdShowSuccess += (adUnitId) => InterstitialAdShowSuccess?.Invoke(adUnitId);
@@ -68,8 +67,6 @@ internal class AndroidDelegate : PlatformDelegate
         Debug.Log($"{TAG} About to call Android showInterstitial method");
         MeticaUnityPluginClass.CallStatic("showInterstitial", callback);
         Debug.Log($"{TAG} Android showInterstitial method called");
-
-        return tcs.Task;
     }
 
     public bool IsInterstitialReady()

--- a/Runtime/ADS/Android/AndroidDelegate.cs
+++ b/Runtime/ADS/Android/AndroidDelegate.cs
@@ -34,12 +34,11 @@ internal class AndroidDelegate : PlatformDelegate
         MeticaUnityPluginClass.CallStatic("initialize", apiKey, appId, userId, baseEndpoint, callback);
     }
 
-    public Task<bool> LoadInterstitialAsync()
+    public void LoadInterstitial()
     {
-        Debug.Log($"{TAG} LoadInterstitialAsync called");
+        Debug.Log($"{TAG} LoadInterstitial called");
 
-        var tcs = new TaskCompletionSource<bool>();
-        var callback = new LoadCallbackProxy(tcs);
+        var callback = new LoadCallbackProxy();
         
         // Wire up all events
         callback.AdLoadSuccess += InterstitialAdLoadSuccess;
@@ -48,8 +47,6 @@ internal class AndroidDelegate : PlatformDelegate
         Debug.Log($"{TAG} About to call Android loadInterstitial method");
         MeticaUnityPluginClass.CallStatic("loadInterstitial", callback);
         Debug.Log($"{TAG} Android loadInterstitial method called");
-
-        return tcs.Task;
     }
 
     public void ShowInterstitial()

--- a/Runtime/ADS/Android/AndroidDelegate.cs
+++ b/Runtime/ADS/Android/AndroidDelegate.cs
@@ -28,10 +28,13 @@ internal class AndroidDelegate : PlatformDelegate
         // TODO tomi
     }
 
-    public void Initialize(string apiKey, string appId, string userId, string baseEndpoint)
+    public Task<bool> Initialize(string apiKey, string appId, string userId, string baseEndpoint)
     {
-        var callback = new InitializeCallbackProxy();
+        var tcs = new TaskCompletionSource<bool>();
+
+        var callback = new InitializeCallbackProxy(tcs);
         MeticaUnityPluginClass.CallStatic("initialize", apiKey, appId, userId, baseEndpoint, callback);
+        return tcs.Task;
     }
 
     public void LoadInterstitial()

--- a/Runtime/ADS/Android/InitializeCallbackProxy.cs
+++ b/Runtime/ADS/Android/InitializeCallbackProxy.cs
@@ -9,18 +9,21 @@ namespace Metica.ADS
 public class InitializeCallbackProxy : AndroidJavaProxy
 {
     private const string TAG = MeticaAds.TAG;
+    private readonly TaskCompletionSource<bool> _tcs;
 
-    public InitializeCallbackProxy()
+
+    public InitializeCallbackProxy(TaskCompletionSource<bool> tcs)
         : base("com.metica.ads.MeticaAdsInitCallback")
     {
         Debug.Log($"{TAG} MeticaAdsInitCallback created");
+        _tcs = tcs;
     }
 
     // Called from Android when ad loads successfully
     public void onInitialized(bool enabled)
     {
         Debug.Log($"{TAG} onInitialized: {enabled}");
+        _tcs.SetResult(enabled);
     }
 }
 }
-

--- a/Runtime/ADS/Android/InitializeCallbackProxy.cs
+++ b/Runtime/ADS/Android/InitializeCallbackProxy.cs
@@ -1,0 +1,26 @@
+// LoadCallbackProxy.cs
+
+using System;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace Metica.ADS
+{
+public class InitializeCallbackProxy : AndroidJavaProxy
+{
+    private const string TAG = MeticaAds.TAG;
+
+    public InitializeCallbackProxy()
+        : base("com.metica.ads.MeticaAdsInitCallback")
+    {
+        Debug.Log($"{TAG} MeticaAdsInitCallback created");
+    }
+
+    // Called from Android when ad loads successfully
+    public void onInitialized(bool enabled)
+    {
+        Debug.Log($"{TAG} onInitialized: {enabled}");
+    }
+}
+}
+

--- a/Runtime/ADS/Android/InitializeCallbackProxy.cs.meta
+++ b/Runtime/ADS/Android/InitializeCallbackProxy.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 06c07db522ee46ff80d2e8d34b433c65
+timeCreated: 1747066221

--- a/Runtime/ADS/Android/LoadCallbackProxy.cs
+++ b/Runtime/ADS/Android/LoadCallbackProxy.cs
@@ -9,14 +9,12 @@ namespace Metica.ADS
 public class LoadCallbackProxy : AndroidJavaProxy
 {
     private const string TAG = MeticaAds.TAG;
-    private readonly TaskCompletionSource<bool> _tcs;
     public event Action<string> AdLoadSuccess;
     public event Action<string, string> AdLoadFailed;
 
-    public LoadCallbackProxy(TaskCompletionSource<bool> tcs)
+    public LoadCallbackProxy()
         : base("com.metica.ads.MeticaLoadAdCallback")
     {
-        _tcs = tcs;
         Debug.Log($"{TAG} LoadCallbackProxy created");
     }
 
@@ -25,7 +23,6 @@ public class LoadCallbackProxy : AndroidJavaProxy
     {
         Debug.Log($"{TAG} onAdLoadSuccess callback received for adUnitId={adUnitId}");
         AdLoadSuccess?.Invoke(adUnitId);
-        _tcs.SetResult(true);
     }
 
     // Called from Android when ad load fails
@@ -33,7 +30,6 @@ public class LoadCallbackProxy : AndroidJavaProxy
     {
         Debug.Log($"{TAG} onAdLoadFailed callback received for adUnitId={adUnitId}, error={error}");
         AdLoadFailed?.Invoke(adUnitId, error);
-        _tcs.SetResult(false);
     }
 }
 }

--- a/Runtime/ADS/Android/ShowCallbackProxy.cs
+++ b/Runtime/ADS/Android/ShowCallbackProxy.cs
@@ -7,7 +7,6 @@ namespace Metica.ADS
 {
 public class ShowCallbackProxy : AndroidJavaProxy
 {    private const string TAG = MeticaAds.TAG;
-    private readonly TaskCompletionSource<bool> _tcs;
     
     // Events for all callbacks
     public event Action<string> AdShowSuccess;
@@ -16,10 +15,9 @@ public class ShowCallbackProxy : AndroidJavaProxy
     public event Action<string> AdClicked;
     public event Action<string> AdRewarded;
     
-    public ShowCallbackProxy(TaskCompletionSource<bool> tcs) 
+    public ShowCallbackProxy() 
         : base("com.metica.ads.MeticaShowAdCallback")
     {
-        _tcs = tcs;
         Debug.Log($"{TAG} ShowCallbackProxy created");
     }
     
@@ -28,7 +26,6 @@ public class ShowCallbackProxy : AndroidJavaProxy
     {
         Debug.Log($"{TAG} onAdShowSuccess callback received for adUnitId={adUnitId}");
         AdShowSuccess?.Invoke(adUnitId);
-        _tcs.SetResult(true);
     }
     
     // Called when ad fails to show
@@ -36,7 +33,6 @@ public class ShowCallbackProxy : AndroidJavaProxy
     {
         Debug.Log($"{TAG} onAdShowFailed callback received for adUnitId={adUnitId}, error={error}");
         AdShowFailed?.Invoke(adUnitId, error);
-        _tcs.SetResult(false);
     }
     
     // Called when ad is hidden (closed)

--- a/Runtime/ADS/MeticaAds.cs
+++ b/Runtime/ADS/MeticaAds.cs
@@ -39,9 +39,9 @@ namespace Metica.ADS
             platformDelegate.SetLogEnabled(logEnabled);
         }
         
-        public static async Task<bool> LoadInterstitialAsync()
+        public static void LoadInterstitial()
         {
-            return await platformDelegate.LoadInterstitialAsync();
+            platformDelegate.LoadInterstitial();
         }
         public static void ShowInterstitial()
         {
@@ -65,7 +65,7 @@ namespace Metica.ADS
 
         public void Initialize(string apiKey, string appId, string userId, string baseEndpoint);
         void SetLogEnabled(bool logEnabled);
-        Task<bool> LoadInterstitialAsync();
+        void LoadInterstitial();
         void ShowInterstitial();
         bool IsInterstitialReady();
     }

--- a/Runtime/ADS/MeticaAds.cs
+++ b/Runtime/ADS/MeticaAds.cs
@@ -30,9 +30,9 @@ namespace Metica.ADS
             platformDelegate.InterstitialAdClicked += MeticaAdsCallbacks.Interstitial.OnAdClickedInternal;
         }
 
-        public static void Initialize()
+        public static async Task<bool> Initialize()
         {
-            platformDelegate.Initialize(MeticaSdk.ApiKey, MeticaSdk.AppId, MeticaSdk.CurrentUserId, MeticaSdk.BaseEndpoint);
+            return await platformDelegate.Initialize(MeticaSdk.ApiKey, MeticaSdk.AppId, MeticaSdk.CurrentUserId, MeticaSdk.BaseEndpoint);
         }
         public static void SetLogEnabled(bool logEnabled) 
         {
@@ -63,7 +63,7 @@ namespace Metica.ADS
         public event Action<string> InterstitialAdHidden;
         public event Action<string> InterstitialAdClicked;
 
-        public void Initialize(string apiKey, string appId, string userId, string baseEndpoint);
+        Task<bool> Initialize(string apiKey, string appId, string userId, string baseEndpoint);
         void SetLogEnabled(bool logEnabled);
         void LoadInterstitial();
         void ShowInterstitial();

--- a/Runtime/ADS/MeticaAds.cs
+++ b/Runtime/ADS/MeticaAds.cs
@@ -39,9 +39,9 @@ namespace Metica.ADS
             platformDelegate.SetLogEnabled(logEnabled);
         }
         
-        public static async Task<bool> LoadInterstitialAsync(string userId)
+        public static async Task<bool> LoadInterstitialAsync()
         {
-            return await platformDelegate.LoadInterstitialAsync(userId);
+            return await platformDelegate.LoadInterstitialAsync();
         }
         public static async Task<bool> ShowInterstitialAsync()
         {
@@ -65,7 +65,7 @@ namespace Metica.ADS
 
         public void Initialize(string apiKey, string appId, string userId, string baseEndpoint);
         void SetLogEnabled(bool logEnabled);
-        Task<bool> LoadInterstitialAsync(string userId);
+        Task<bool> LoadInterstitialAsync();
         Task<bool> ShowInterstitialAsync();
         bool IsInterstitialReady();
     }

--- a/Runtime/ADS/MeticaAds.cs
+++ b/Runtime/ADS/MeticaAds.cs
@@ -43,9 +43,9 @@ namespace Metica.ADS
         {
             return await platformDelegate.LoadInterstitialAsync();
         }
-        public static async Task<bool> ShowInterstitialAsync()
+        public static void ShowInterstitial()
         {
-            return await platformDelegate.ShowInterstitialAsync();
+            platformDelegate.ShowInterstitial();
         }
 
         public static bool IsInterstitialReady()
@@ -66,7 +66,7 @@ namespace Metica.ADS
         public void Initialize(string apiKey, string appId, string userId, string baseEndpoint);
         void SetLogEnabled(bool logEnabled);
         Task<bool> LoadInterstitialAsync();
-        Task<bool> ShowInterstitialAsync();
+        void ShowInterstitial();
         bool IsInterstitialReady();
     }
 }

--- a/Runtime/ADS/MeticaAds.cs
+++ b/Runtime/ADS/MeticaAds.cs
@@ -32,7 +32,7 @@ namespace Metica.ADS
 
         public static void Initialize()
         {
-            platformDelegate.Initialize(MeticaSdk.ApiKey, MeticaSdk.AppId, MeticaSdk.BaseEndpoint);
+            platformDelegate.Initialize(MeticaSdk.ApiKey, MeticaSdk.AppId, MeticaSdk.CurrentUserId, MeticaSdk.BaseEndpoint);
         }
         public static void SetLogEnabled(bool logEnabled) 
         {
@@ -63,7 +63,7 @@ namespace Metica.ADS
         public event Action<string> InterstitialAdHidden;
         public event Action<string> InterstitialAdClicked;
 
-        public void Initialize(string apiKey, string appId, string baseEndpoint);
+        public void Initialize(string apiKey, string appId, string userId, string baseEndpoint);
         void SetLogEnabled(bool logEnabled);
         Task<bool> LoadInterstitialAsync(string userId);
         Task<bool> ShowInterstitialAsync();


### PR DESCRIPTION
This commit improves the ads integration by:

1. Making initialization process asynchronous with proper callback
2. Moving userId from individual ad methods to initialization
3. Simplifying LoadInterstitial and ShowInterstitial to use event-based callbacks instead of Tasks
4. Adding InitializeCallbackProxy to handle initialization callbacks from Android

These changes align the Unity plugin with the updated Android implementation and provide a more consistent API surface that follows Applovin's conventions.