### PR TITLE
MET-2802: Fix JSON deserialization crash on IL2CPP builds

### DIFF
--- a/Runtime/ADS/MeticaAds.cs
+++ b/Runtime/ADS/MeticaAds.cs
@@ -13,12 +13,14 @@ namespace Metica.ADS
 
         static MeticaAds()
         {
-#if UNITY_ANDROID
+#if UNITY_EDITOR
+            platformDelegate = new UnityPlayer.UnityPlayerDelegate();
+#elif UNITY_ANDROID
             platformDelegate = new Android.AndroidDelegate();
-#endif
-
-#if UNITY_IOS
+#elif UNITY_IOS
             platformDelegate = new IOS.IOSDelegate();
+#else
+            throw new PlatformNotSupportedException("MeticaAds is only supported on Android, iOS, and Unity Editor platforms.");
 #endif
             // Interstitial ad callbacks
             platformDelegate.InterstitialAdLoadSuccess += MeticaAdsCallbacks.Interstitial.OnAdLoadSuccessInternal;

--- a/Runtime/ADS/UnityPlayer.meta
+++ b/Runtime/ADS/UnityPlayer.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1cb22081333645c88409fa91026b0d14
+timeCreated: 1748628941

--- a/Runtime/ADS/UnityPlayer/UnityPlayerDelegate.cs
+++ b/Runtime/ADS/UnityPlayer/UnityPlayerDelegate.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace Metica.ADS.UnityPlayer
+{
+internal class UnityPlayerDelegate : PlatformDelegate
+{
+    // Mock events - these won't actually fire in editor
+    public event Action<MeticaAd> InterstitialAdLoadSuccess;
+    public event Action<string> InterstitialAdLoadFailed;
+    public event Action<MeticaAd> InterstitialAdShowSuccess;
+    public event Action<MeticaAd, string> InterstitialAdShowFailed;
+    public event Action<MeticaAd> InterstitialAdHidden;
+    public event Action<MeticaAd> InterstitialAdClicked;
+    public event Action<MeticaAd> InterstitialAdRevenuePaid;
+
+    public event Action<MeticaAd> RewardedAdLoadSuccess;
+    public event Action<string> RewardedAdLoadFailed;
+    public event Action<MeticaAd> RewardedAdShowSuccess;
+    public event Action<MeticaAd, string> RewardedAdShowFailed;
+    public event Action<MeticaAd> RewardedAdHidden;
+    public event Action<MeticaAd> RewardedAdClicked;
+    public event Action<MeticaAd> RewardedAdRewarded;
+    public event Action<MeticaAd> RewardedAdRevenuePaid;
+
+    public Task<bool> InitializeAsync(string apiKey, string appId, string userId, string version, string baseEndpoint)
+    {
+        Debug.Log("[MeticaAds Unity] Mock initialization - always returns false");
+        return Task.FromResult(false);
+    }
+
+    public void SetLogEnabled(bool logEnabled)
+    {
+        Debug.Log($"[MeticaAds Unity] Mock SetLogEnabled: {logEnabled}");
+    }
+
+    public void LoadInterstitial()
+    {
+        Debug.Log("[MeticaAds Unity] Mock LoadInterstitial called");
+    }
+
+    public void ShowInterstitial()
+    {
+        Debug.Log("[MeticaAds Unity] Mock ShowInterstitial called");
+    }
+
+    public bool IsInterstitialReady()
+    {
+        Debug.Log("[MeticaAds Unity] Mock IsInterstitialReady - always returns false");
+        return false;
+    }
+
+    public void LoadRewarded()
+    {
+        Debug.Log("[MeticaAds Unity] Mock LoadRewarded called");
+    }
+
+    public void ShowRewarded()
+    {
+        Debug.Log("[MeticaAds Unity] Mock ShowRewarded called");
+    }
+
+    public bool IsRewardedReady()
+    {
+        Debug.Log("[MeticaAds Unity] Mock IsRewardedReady - always returns false");
+        return false;
+    }
+}
+}

--- a/Runtime/ADS/UnityPlayer/UnityPlayerDelegate.cs.meta
+++ b/Runtime/ADS/UnityPlayer/UnityPlayerDelegate.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4cce6319e10c4062905cb8b47c3b0662
+timeCreated: 1748629061

--- a/Runtime/SDK/ConfigManager.cs
+++ b/Runtime/SDK/ConfigManager.cs
@@ -1,18 +1,20 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
-
 using Metica.Core;
 using Metica.Network;
 using Metica.SDK.Model;
+using Newtonsoft.Json;
+using UnityEngine.Scripting;
 
 namespace Metica.SDK
 {
+    [Preserve]
     [System.Serializable]
     public class ConfigResult : IMeticaHttpResult
     {
         // TODO : ideally fields should be readonly or with private setter
 
+        [Preserve]
         [JsonExtensionData] // Needed when we want the root (anonymous dictionary in this case) to go in a specific field
         public Dictionary<string, object> Configs { get; set; }
 

--- a/Runtime/SDK/OfferManager.cs
+++ b/Runtime/SDK/OfferManager.cs
@@ -149,7 +149,7 @@ namespace Metica.SDK
 
             // We only retrieve via http the pending placements
             var url = _url;
-            if(placements != null && placements.Length > 0)
+            if(placements.Length > 0)
             {
                 url = $"{url}?placements=";
                 for (int i = 0; i < placements.Length; i++)

--- a/Runtime/SDK/OfferManager.cs
+++ b/Runtime/SDK/OfferManager.cs
@@ -1,17 +1,19 @@
-using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-
 using Metica.Core;
 using Metica.Network;
 using Metica.SDK.Model;
+using Newtonsoft.Json;
+using UnityEngine.Scripting;
 
 namespace Metica.SDK
 {
+    [Preserve]
     [System.Serializable]
     public class OfferResult : IMeticaHttpResult
     {
+        [Preserve]
         [JsonProperty("placements")]
         public Dictionary<string, List<Offer>> placements { get; set; }
         //[Obsolete("Please use 'Placements'")]


### PR DESCRIPTION
Add [Preserve] attributes to ConfigResult and OfferResult classes to prevent 
IL2CPP code stripping. This fixes JsonSerializationException when deserializing 
extension data on Android/iOS builds.

The issue occurred because IL2CPP was stripping the default constructors and 
property initializers, causing the extension data collections to be null during 
deserialization. This affected all publishers using code stripping.

Fixes: Starberry crash issue
Affects: All Unity projects with code stripping enabled