### PR TITLE
Update Metica.ADS.asmdef configuration

### DIFF
--- a/Runtime/ADS/Metica.ADS.asmdef
+++ b/Runtime/ADS/Metica.ADS.asmdef
@@ -1,7 +1,17 @@
 {
-  "name": "Metica.ADS",
-  "references": [
-    "Metica.SDK",
-    "MaxSdk.Scripts"
-  ]
+    "name": "Metica.ADS",
+    "rootNamespace": "",
+    "references": [
+        "Metica.SDK",
+        "MaxSdk.Scripts"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }


### PR DESCRIPTION
Fix issue with new projects or newly opened demo project.
All platforms were excluded in `Metica.ADS.asmdef` file, causing it to not be loaded. Now set to _Any platform_.