### PR TITLE
[MET-3005] Time based event dispatch

### DIFF
--- a/Runtime/SDK/EventManager.cs
+++ b/Runtime/SDK/EventManager.cs
@@ -51,8 +51,10 @@ namespace Metica.SDK
         private readonly ITimeSource _timeSource = new SystemDateTimeSource();
         private readonly SdkConfig _sdkConfig;
 
-        public const uint DefaultEventQueueCountTrigger = 64;
+        public const uint DefaultEventQueueCountTrigger = 64; // Rename to DefaultQueueFlushCountTrigger
+        private const uint DefaultQueueFlushTimeoutSecondsTrigger = 10;
         private readonly uint _eventQueueCountTrigger;
+        private long _lastEventDispatchUnixTime = 0;
 
         private List<object> _events;
 
@@ -67,6 +69,7 @@ namespace Metica.SDK
             _events = new List<object>();
             OnEventsDispatch += DispatchHandler;
             _eventQueueCountTrigger = eventQueueCountTrigger;
+            _lastEventDispatchUnixTime = _timeSource.EpochSeconds();
         }
 
         /// <summary>
@@ -75,7 +78,7 @@ namespace Metica.SDK
         /// and
         /// <see cref="QueueEventWithProductId(string, string, string, string, Dictionary{string, object}, Dictionary{string, object})"/>
         /// both use this method but it's perfectly fine to use it directly.
-        /// This method also calls the <see cref="DispatchEvents"/> with a fire and forget style call <code>_ = Dispatch();</code>.
+        /// This method also calls the <see cref="DispatchEvents"/> with a fire and forget style call <code>_ = Dispatch();</code> when certain conditions are met.
         /// </summary>
         internal void QueueEventAsync(string userId, string appId, string eventType, Dictionary<string, object> eventFields, Dictionary<string, object> customPayload)
         {
@@ -99,8 +102,11 @@ namespace Metica.SDK
 
             Log.Debug(() => $"Queueing {eventType} event, id={requestBody[FieldNames.EventId]}");
 
-            if(_events.Count >= _eventQueueCountTrigger)
+            long unixTimeSinceLastDispatch = _timeSource.EpochSeconds() - _lastEventDispatchUnixTime;
+
+            if (_events.Count >= _eventQueueCountTrigger || unixTimeSinceLastDispatch >= DefaultQueueFlushTimeoutSecondsTrigger)
             {
+                // Log.Debug(() => (_events.Count >= _eventQueueCountTrigger)? "Dispatch : reason=count" : "Dispatch : reason=time" );
                 _ = DispatchEvents();
             }
         }
@@ -194,14 +200,21 @@ namespace Metica.SDK
                 var httpResponse = await _httpService.PostAsync(_url, body, "application/json", useCache: false);
                 _events.Clear();
                 EventDispatchResult result = ResponseToResult<EventDispatchResult>(httpResponse);
+                if (result.Status != HttpResponse.ResultStatus.Success)
+                {
+                    // TODO : does this case need retry or other logic? Queue is cleared at this stage,
+                    // do we need to ensure the event ingestion happened?
+                    Log.Warning(() => $"EventManager.DispatchEvents: Response indicates failure: {result.Error}. Queue has been cleared.");
+                }
                 result.OriginalRequestBody = body;
                 OnEventsDispatch?.Invoke(result);
             }
-            catch (System.Net.Http.HttpRequestException exception) 
+            catch (System.Net.Http.HttpRequestException exception)
                 when (exception.InnerException is TimeoutException || exception.Message.Contains("timed out"))
             {
                 Log.Error(() => $"EventManager.DispatchEvents: Request timed out: {exception.Message}");
-                EventDispatchResult result = new EventDispatchResult {
+                EventDispatchResult result = new EventDispatchResult
+                {
                     Status = HttpResponse.ResultStatus.Failure,
                     Error = $"Timeout: {exception.Message}",
                     RawContent = null,
@@ -212,13 +225,18 @@ namespace Metica.SDK
             catch (Exception exception)
             {
                 Log.Error(() => $"EventManager.DispatchEvents: Exception: {exception.Message}");
-                EventDispatchResult result = new EventDispatchResult {
+                EventDispatchResult result = new EventDispatchResult
+                {
                     Status = HttpResponse.ResultStatus.Failure,
                     Error = exception.Message,
                     RawContent = null,
                     OriginalRequestBody = body
                 };
                 OnEventsDispatch?.Invoke(result);
+            }
+            finally
+            {
+                _lastEventDispatchUnixTime = _timeSource.EpochSeconds();
             }
         }
 

--- a/Runtime/SDK/EventManager.cs
+++ b/Runtime/SDK/EventManager.cs
@@ -49,7 +49,6 @@ namespace Metica.SDK
 
         private readonly IMeticaAttributesProvider _meticaAttributesProvider;
         private readonly ITimeSource _timeSource = new SystemDateTimeSource();
-        private readonly SdkConfig _sdkConfig;
 
         public const uint DefaultEventQueueCountTrigger = 64; // Rename to DefaultQueueFlushCountTrigger
         private const uint DefaultQueueFlushTimeoutSecondsTrigger = 10;
@@ -202,8 +201,9 @@ namespace Metica.SDK
                 EventDispatchResult result = ResponseToResult<EventDispatchResult>(httpResponse);
                 if (result.Status != HttpResponse.ResultStatus.Success)
                 {
-                    // TODO : does this case need retry or other logic? Queue is cleared at this stage,
-                    // do we need to ensure the event ingestion happened?
+                    // TODO : does this case need retry or other logic? Queue is cleared at this stage
+                    // and we may lose events.
+                    // Do we need to ensure the event ingestion happened?
                     Log.Warning(() => $"EventManager.DispatchEvents: Response indicates failure: {result.Error}. Queue has been cleared.");
                 }
                 result.OriginalRequestBody = body;

--- a/Runtime/SDK/OfferManager.cs
+++ b/Runtime/SDK/OfferManager.cs
@@ -109,7 +109,7 @@ namespace Metica.SDK
             if (placements == null)
             {
                 Log.Error(() =>
-                    "Null placements were passed. This could be due to an inconsistent initialization of the SDK.");
+                    "Null placements were passed. This could be due to an inconsistent initialization of the SDK (e.g. a wrong appId).");
                 return;
             }
 
@@ -173,11 +173,9 @@ namespace Metica.SDK
                 JsonSerializerSettings settings = new JsonSerializerSettings();
                 settings.NullValueHandling = NullValueHandling.Ignore;
 
-                var httpResponse = await _httpService.PostAsync(url, JsonConvert.SerializeObject(requestBody, settings),
-                    "application/json");
+                var httpResponse = await _httpService.PostAsync(url, JsonConvert.SerializeObject(requestBody, settings), "application/json");
                 OfferResult offerResult = ResponseToResult<OfferResult>(httpResponse);
-                await AddOrUpdateStorage(offerResult
-                    .placements); // Add or update storage with the new received placements.
+                await AddOrUpdateStorage(offerResult.placements); // Add or update storage with the new received placements.
                 return offerResult;
             }
             catch (System.Net.Http.HttpRequestException exception)


### PR DESCRIPTION
This adds a check on a time interval.
The technique sticks to the current design where `QueueEvent` must be called for the `EventManager` to perform a dispatch, if due.

I have evaluated the alternative to implement a separate thread that calls the dispatch method at regular, real time intervals, but threads should be used like silver bullets and I don't think it's worth using one since it still wouldn't ensure that zero events remain hanging. Adjusting count threshold and time interval, combined with triggers based on application lifetime event, should already take us very close to the achievable reliability and a separate thread would barely (if at all) give better results.

There is a potential issue I am pointing out at line EventManager.cs:204 where the event queue might be cleared event if hasn't been dispatched.