### PR TITLE
[MET-2975] Deprecate public use of `DeviceInfo` and public methods that take one

### DIFF
--- a/Runtime/SDK/ConfigManager.cs
+++ b/Runtime/SDK/ConfigManager.cs
@@ -1,12 +1,13 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+using UnityEngine.Scripting; // TODO : MET-3509 : break dependency from UnityEngine
+using SystemInfo = UnityEngine.Device.SystemInfo;
+
 using Metica.Core;
 using Metica.Network;
 using Metica.SDK.Model;
-using Newtonsoft.Json;
-using UnityEngine;
-using UnityEngine.Scripting;
-using SystemInfo = UnityEngine.Device.SystemInfo;
 
 namespace Metica.SDK
 {
@@ -87,7 +88,7 @@ namespace Metica.SDK
                 settings.NullValueHandling = NullValueHandling.Ignore;
 
                 var httpResponse = await _httpService.PostAsync(url, JsonConvert.SerializeObject(requestBody, settings), "application/json");
-                Debug.Log("MeticaSdk ConfigManager.GetConfigsAsync: Success: {httpResponse.ResponseContent}");
+                Log.Debug(() => $"MeticaSdk ConfigManager.GetConfigsAsync: Success: {httpResponse.ResponseContent}");
                 return ResponseToResult<ConfigResult>(httpResponse);
             }
             catch (System.Net.Http.HttpRequestException exception)

--- a/Runtime/SDK/ConfigManager.cs
+++ b/Runtime/SDK/ConfigManager.cs
@@ -70,7 +70,7 @@ namespace Metica.SDK
                     { FieldNames.ConfigKeys, configKeys },
                     // Use the augmented dictionary here
                     { FieldNames.UserData, finalUserData },
-                    { FieldNames.DeviceInfo, deviceInfo ?? _deviceInfoProvider.GetDeviceInfo() },
+                    { FieldNames.DeviceInfo, _deviceInfoProvider.GetDeviceInfo() },
                 };
 
                 var url = _url;

--- a/Runtime/SDK/EventManager.cs
+++ b/Runtime/SDK/EventManager.cs
@@ -66,7 +66,10 @@ namespace Metica.SDK
         {
             _meticaAttributesProvider = meticaAttributesProvider;
             _events = new List<object>();
-            OnEventsDispatch += DispatchHandler;
+            if (Log.CurrentLogLevel == LogLevel.Debug)
+            {
+                OnEventsDispatch += DispatchHandler;
+            }
             _eventQueueCountTrigger = eventQueueCountTrigger;
             _lastEventDispatchUnixTime = _timeSource.EpochSeconds();
         }
@@ -201,9 +204,8 @@ namespace Metica.SDK
                 EventDispatchResult result = ResponseToResult<EventDispatchResult>(httpResponse);
                 if (result.Status != HttpResponse.ResultStatus.Success)
                 {
-                    // TODO : does this case need retry or other logic? Queue is cleared at this stage
-                    // and we may lose events.
-                    // Do we need to ensure the event ingestion happened?
+                    // TODO : https://linear.app/metica/issue/MET-3515/
+                    // does this case need retry logic? Queue is cleared at this stage thus events may get lost.
                     Log.Warning(() => $"EventManager.DispatchEvents: Response indicates failure: {result.Error}. Queue has been cleared.");
                 }
                 result.OriginalRequestBody = body;

--- a/Runtime/SDK/MeticaSdk.cs
+++ b/Runtime/SDK/MeticaSdk.cs
@@ -10,8 +10,12 @@ namespace Metica.SDK
 {
     public interface IMeticaSdk
     {
-        Task<ConfigResult> GetConfigsAsync(List<string> configKeys = null, Dictionary<string, object> userData = null, DeviceInfo deviceInfo = null);
-        Task<OfferResult> GetOffersAsync(string[] placements, Dictionary<string, object> userData = null, DeviceInfo deviceInfo = null);
+        Task<ConfigResult> GetConfigsAsync(List<string> configKeys = null, Dictionary<string, object> userData = null);
+        [Obsolete]
+        Task<ConfigResult> GetConfigsAsync(List<string> configKeys, Dictionary<string, object> userData, DeviceInfo deviceInfo);
+        Task<OfferResult> GetOffersAsync(string[] placements, Dictionary<string, object> userData = null);
+        [Obsolete]
+        Task<OfferResult> GetOffersAsync(string[] placements, Dictionary<string, object> userData, DeviceInfo deviceInfo);
         void LogAdRevenueEvent(string placement, string type, string source, string currencyCode, double totalAmount, Dictionary<string, object> customPayload = null);
         void LogCustomEvent(string customEventType, Dictionary<string, object> customPayload = null);
         void LogInstallEvent(Dictionary<string, object> customPayload = null);
@@ -42,7 +46,6 @@ namespace Metica.SDK
 
         private readonly SdkConfig _sdkConfig;
         private readonly IHttpService _http;
-        private readonly IDeviceInfoProvider _deviceInfoProvider;
         private readonly OfferManager _offerManager;
         private readonly ConfigManager _configManager;
         private readonly EventManager _eventManager;
@@ -107,12 +110,18 @@ namespace Metica.SDK
             Registry.Register<IMeticaSdk>(this);
         }
 
-        public async Task<OfferResult> GetOffersAsync(string[] placements, Dictionary<string, object> userData = null, DeviceInfo deviceInfo = null)
-            => await _offerManager.GetOffersAsync(CurrentUserId, placements, userData, deviceInfo);
+        public async Task<OfferResult> GetOffersAsync(string[] placements, Dictionary<string, object> userData = null)
+            => await _offerManager.GetOffersAsync(CurrentUserId, placements, userData);
+        [Obsolete]
+        public async Task<OfferResult> GetOffersAsync(string[] placements, Dictionary<string, object> userData, DeviceInfo deviceInfo)
+            => await _offerManager.GetOffersAsync(CurrentUserId, placements, userData);
 
 
-        public async Task<ConfigResult> GetConfigsAsync(List<string> configKeys = null, Dictionary<string, object> userProperties = null, DeviceInfo deviceInfo = null)
-            => await _configManager.GetConfigsAsync(CurrentUserId, configKeys, userProperties, deviceInfo);
+        public async Task<ConfigResult> GetConfigsAsync(List<string> configKeys = null, Dictionary<string, object> userProperties = null)
+            => await _configManager.GetConfigsAsync(CurrentUserId, configKeys, userProperties);
+        [Obsolete]
+        public async Task<ConfigResult> GetConfigsAsync(List<string> configKeys, Dictionary<string, object> userProperties, DeviceInfo deviceInfo)
+            => await _configManager.GetConfigsAsync(CurrentUserId, configKeys, userProperties);
 
 
         public void LogLoginEvent(Dictionary<string, object> customPayload = null)

--- a/Runtime/SDK/Model.cs
+++ b/Runtime/SDK/Model.cs
@@ -90,6 +90,8 @@ namespace Metica.SDK.Model
         public string timezone;
         public string locale;
         public string appVersion;
+        public string osVersion;
+        // public string machineName;
 
         public override string ToString()
         {

--- a/Runtime/SDK/Model.cs
+++ b/Runtime/SDK/Model.cs
@@ -83,6 +83,9 @@ namespace Metica.SDK.Model
         GooglePlayStore
     }
 
+    /// <summary>
+    /// Device information.
+    /// </summary>
     [Serializable]
     public class DeviceInfo
     {
@@ -90,8 +93,6 @@ namespace Metica.SDK.Model
         public string timezone;
         public string locale;
         public string appVersion;
-        public string osVersion;
-        // public string machineName;
 
         public override string ToString()
         {

--- a/Runtime/Unity/DeviceInfoProvider.cs
+++ b/Runtime/Unity/DeviceInfoProvider.cs
@@ -18,12 +18,17 @@ namespace Metica.Unity
             var timezone = ((systemTz >= TimeSpan.Zero) ? "+" : "-") + systemTz.ToString(@"hh\:mm");
             string locale = Thread.CurrentThread.CurrentCulture.Name;
             var appVersion = Application.version;
+            var osVersion = Environment.OSVersion.VersionString;
+            // var machineName = Environment.MachineName;
 
-            return new DeviceInfo() {
+            return new DeviceInfo()
+            {
                 store = MapRuntimePlatformToStoreType(Application.platform)?.ToString(),
                 timezone = timezone,
                 locale = locale,
-                appVersion = appVersion
+                appVersion = appVersion,
+                osVersion = osVersion,
+                // machineName = machineName
             };
         }
 

--- a/Runtime/Unity/DeviceInfoProvider.cs
+++ b/Runtime/Unity/DeviceInfoProvider.cs
@@ -9,17 +9,20 @@ namespace Metica.Unity
 {
     /// <summary>
     /// Unity implementation of <see cref="IDeviceInfoProvider"/>.
+    /// The obtained information is cached so it is collected <b>once</b> and remains unchanged for the whole application lifetime.
     /// </summary>
     public class DeviceInfoProvider : IDeviceInfoProvider
     {
-        public DeviceInfo GetDeviceInfo()
+        private readonly Lazy<DeviceInfo> _cachedDeviceInfo = new Lazy<DeviceInfo>(() => CreateDeviceInfo());
+
+        public DeviceInfo GetDeviceInfo() => _cachedDeviceInfo.Value;
+
+        private static DeviceInfo CreateDeviceInfo()
         {
             var systemTz = TimeZoneInfo.Local.BaseUtcOffset;
             var timezone = ((systemTz >= TimeSpan.Zero) ? "+" : "-") + systemTz.ToString(@"hh\:mm");
             string locale = Thread.CurrentThread.CurrentCulture.Name;
             var appVersion = Application.version;
-            var osVersion = Environment.OSVersion.VersionString;
-            // var machineName = Environment.MachineName;
 
             return new DeviceInfo()
             {
@@ -27,8 +30,6 @@ namespace Metica.Unity
                 timezone = timezone,
                 locale = locale,
                 appVersion = appVersion,
-                osVersion = osVersion,
-                // machineName = machineName
             };
         }
 

--- a/Runtime/Unity/MeticaAPI.cs
+++ b/Runtime/Unity/MeticaAPI.cs
@@ -102,63 +102,73 @@ namespace Metica.Unity
             responseCallback?.Invoke(new SdkResultImpl<T>().WithResult(task.Result));
         }
 
+        [Obsolete]
+        public static void GetConfig(MeticaSdkDelegate<Dictionary<string, object>> responseCallback, List<string> configKeys, Dictionary<string, object> userProperties, DeviceInfo deviceInfo)
+            => GetConfig(responseCallback, configKeys, userProperties);
+
         /// <summary>
         /// Gets all or the StartConfigs with the given keys.
         /// </summary>
         /// <param name="responseCallback">Callback method to process the result as a dictionary.</param>
         /// <param name="configKeys">List of keys of required SmartConfigs. Leave to null or empty to get all SmartConfigs.</param>
         /// <param name="userProperties">Real-time user state data to override pre-ingested user state attributes, conforms to userStateAttributes.</param>
-        /// <param name="deviceInfo">A <see cref="DeviceInfo"/> object. If null, one will be automatically created to retrieve information about the device.</param>
         /// <remarks>
         /// ## ROADMAP
         /// - TODO : make this obsolete and use a response callback with <see cref="ConfigResult"/> as in
-        /// <see cref="GetConfigAsConfigResult(MeticaSdkDelegate{ConfigResult}, List{string}, Dictionary{string, object}, DeviceInfo)"/>
+        /// <see cref="GetConfigAsConfigResult(MeticaSdkDelegate{ConfigResult}, List{string}, Dictionary{string, object})"/>
         /// </remarks>
-        public static void GetConfig(MeticaSdkDelegate<Dictionary<string, object>> responseCallback, List<string> configKeys = null, Dictionary<string, object> userProperties = null, DeviceInfo deviceInfo = null)
+        public static void GetConfig(MeticaSdkDelegate<Dictionary<string, object>> responseCallback, List<string> configKeys = null, Dictionary<string, object> userProperties = null)
         {
-            CoroutineRunner.Instance.RunCoroutine(GetConfigAsDictionaryCoroutine(responseCallback, configKeys, userProperties, deviceInfo));
+            CoroutineRunner.Instance.RunCoroutine(GetConfigAsDictionaryCoroutine(responseCallback, configKeys, userProperties));
         }
+
+
+        [Obsolete]
+        public static void GetConfigAsConfigResult(MeticaSdkDelegate<ConfigResult> responseCallback, List<string> configKeys, Dictionary<string, object> userProperties, DeviceInfo deviceInfo)
+            => GetConfigAsConfigResult(responseCallback, configKeys, userProperties);
         /// <summary>
         /// Gets all or the StartConfigs with the given keys.
         /// </summary>
         /// <param name="responseCallback">Callback method to process the result as a <see cref="ConfigResult"/>.</param>
         /// <param name="configKeys">List of keys of required SmartConfigs. Leave to null or empty to get all SmartConfigs.</param>
         /// <param name="userProperties">Real-time user state data to override pre-ingested user state attributes, conforms to userStateAttributes.</param>
-        /// <param name="deviceInfo">A <see cref="DeviceInfo"/> object. If null, one will be automatically created to retrieve information about the device.</param>
         /// <remarks>
         /// ## ROADMAP
         /// - TODO [BREAKING CHANGE] : This will be renamed back to GetConfig and will be the only way to get the result.
         /// - TODO : we'll likely introduce static async versions for some or all of the methods as alternatives to the current static void versions.
         /// </remarks>
-        public static void GetConfigAsConfigResult(MeticaSdkDelegate<ConfigResult> responseCallback, List<string> configKeys = null, Dictionary<string, object> userProperties = null, DeviceInfo deviceInfo = null)
+        public static void GetConfigAsConfigResult(MeticaSdkDelegate<ConfigResult> responseCallback, List<string> configKeys = null, Dictionary<string, object> userProperties = null)
         {
-            CoroutineRunner.Instance.RunCoroutine(GetConfigAsConfigResultCoroutine(responseCallback, configKeys, userProperties, deviceInfo));
+            CoroutineRunner.Instance.RunCoroutine(GetConfigAsConfigResultCoroutine(responseCallback, configKeys, userProperties));
         }
 
-        private static IEnumerator GetConfigAsDictionaryCoroutine(MeticaSdkDelegate<Dictionary<string, object>> responseCallback, List<string> configKeys = null, Dictionary<string, object> userProperties = null, DeviceInfo deviceInfo = null)
+        private static IEnumerator GetConfigAsDictionaryCoroutine(MeticaSdkDelegate<Dictionary<string, object>> responseCallback, List<string> configKeys = null, Dictionary<string, object> userProperties = null)
         {
-            yield return RunAsyncTaskCoroutine(() => SDK.GetConfigsAsync(configKeys, userProperties, deviceInfo), (result) =>
+            yield return RunAsyncTaskCoroutine(() => SDK.GetConfigsAsync(configKeys, userProperties), (result) =>
             {
                 responseCallback?.Invoke(new SdkResultImpl<Dictionary<string, object>>().WithResult(result.Result.Configs));
             });
         }
 
-        private static IEnumerator GetConfigAsConfigResultCoroutine(MeticaSdkDelegate<ConfigResult> responseCallback, List<string> configKeys = null, Dictionary<string, object> userProperties = null, DeviceInfo deviceInfo = null)
+        private static IEnumerator GetConfigAsConfigResultCoroutine(MeticaSdkDelegate<ConfigResult> responseCallback, List<string> configKeys = null, Dictionary<string, object> userProperties = null)
         {
-            yield return RunAsyncTaskCoroutine(() => SDK.GetConfigsAsync(configKeys, userProperties, deviceInfo), (result) =>
+            yield return RunAsyncTaskCoroutine(() => SDK.GetConfigsAsync(configKeys, userProperties), (result) =>
             {
                 responseCallback?.Invoke(new SdkResultImpl<ConfigResult>().WithResult(result.Result));
             });
         }
 
+
+        [Obsolete]
+        public static void GetOffers(String[] placements, MeticaSdkDelegate<OfferResult> responseCallback, Dictionary<string, object> userProperties, DeviceInfo deviceInfo)
+            => GetOffers(placements, responseCallback, userProperties);
         /// <summary>
         /// Gets the placements with the given IDs. if placement is null or empty, all placements and offers will be fetched.
         /// </summary>
         /// <param name="placements">Ad array of placement IDs. If this field is null or empty, all placements and offers will be fetched.</param>
         /// <param name="responseCallback">A callback method that takes an <see cref="OfferResult"/> to process it when the data is received.</param>
         /// <param name="userProperties">Real-time user state data to override pre-ingested user state attributes, conforms to its userStateAttributes property.</param>
-        /// <param name="deviceInfo">A <see cref="DeviceInfo"/> object. If null, one will be created automatically.</param>
-        /// <seealso cref="GetOffers(string[], MeticaSdkDelegate{Dictionary{string, List{Offer}}}, Dictionary{string, object}, DeviceInfo)"/>
+        /// <seealso cref="GetOffers(string[], MeticaSdkDelegate{Dictionary{string, List{Offer}}}, Dictionary{string, object})"/>
         /// <remarks>
         /// Example call:
         /// <code>
@@ -178,18 +188,22 @@ namespace Metica.Unity
         /// }
         /// </code>
         /// </remarks>
-        public static void GetOffers(String[] placements, MeticaSdkDelegate<OfferResult> responseCallback, Dictionary<string, object> userProperties = null, DeviceInfo deviceInfo = null)
+        public static void GetOffers(String[] placements, MeticaSdkDelegate<OfferResult> responseCallback, Dictionary<string, object> userProperties = null) 
         {
-            CoroutineRunner.Instance.RunCoroutine(GetOffersAsOfferResultCoroutine(placements, responseCallback, userProperties, deviceInfo));
+            CoroutineRunner.Instance.RunCoroutine(GetOffersAsOfferResultCoroutine(placements, responseCallback, userProperties));
         }
+
+
+        [Obsolete]
+        public static void GetOffersAsDictionary(String[] placements, MeticaSdkDelegate<Dictionary<string, List<Offer>>> responseCallback, Dictionary<string, object> userProperties = null, DeviceInfo deviceInfo = null)
+            => GetOffersAsDictionary(placements, responseCallback, userProperties);
         /// <summary>
         /// Gets the placements with the given IDs. if placement is null or empty, all placements and offers will be fetched.
         /// </summary>
         /// <param name="placements">Ad array of placement IDs. If this field is null or empty, all placements and offers will be fetched.</param>
         /// <param name="responseCallback">A callback method that takes a <code>Dictionary<string, List<Offer>></code> to process it when the data is received.</param>
         /// <param name="userProperties">Real-time user state data to override pre-ingested user state attributes, conforms to its userStateAttributes property.</param>
-        /// <param name="deviceInfo">A <see cref="DeviceInfo"/> object. If null, one will be created automatically.</param>
-        /// <seealso cref="GetOffers(string[], MeticaSdkDelegate{OfferResult}, Dictionary{string, object}, DeviceInfo)"/>
+        /// <seealso cref="GetOffers(string[], MeticaSdkDelegate{OfferResult}, Dictionary{string, object})"/>
         /// <remarks>
         /// Example call:
         /// <code>
@@ -211,16 +225,16 @@ namespace Metica.Unity
         /// </code>
         /// ## ROADMAP
         /// 
-        /// - TODO : This call will be removed in favour of <see cref="GetOffers(string[], MeticaSdkDelegate{OfferResult}, Dictionary{string, object}, DeviceInfo)"/>.
+        /// - TODO : This call will be removed in favour of <see cref="GetOffers(string[], MeticaSdkDelegate{OfferResult}, Dictionary{string, object})"/>.
         /// </remarks>
-        public static void GetOffersAsDictionary(String[] placements, MeticaSdkDelegate<Dictionary<string, List<Offer>>> responseCallback, Dictionary<string, object> userProperties = null, DeviceInfo deviceInfo = null)
+        public static void GetOffersAsDictionary(String[] placements, MeticaSdkDelegate<Dictionary<string, List<Offer>>> responseCallback, Dictionary<string, object> userProperties)
         {
-            CoroutineRunner.Instance.RunCoroutine(GetOffersAsDictionaryCoroutine(placements, responseCallback, userProperties, deviceInfo));
+            CoroutineRunner.Instance.RunCoroutine(GetOffersAsDictionaryCoroutine(placements, responseCallback, userProperties));
         }
 
-        private static IEnumerator GetOffersAsOfferResultCoroutine(String[] placements, MeticaSdkDelegate<OfferResult> responseCallback, Dictionary<string, object> userProperties = null, DeviceInfo deviceInfo = null)
+        private static IEnumerator GetOffersAsOfferResultCoroutine(String[] placements, MeticaSdkDelegate<OfferResult> responseCallback, Dictionary<string, object> userProperties = null)
         {
-            yield return RunAsyncTaskCoroutine(() => SDK.GetOffersAsync(placements, userProperties, deviceInfo), (result) =>
+            yield return RunAsyncTaskCoroutine(() => SDK.GetOffersAsync(placements, userProperties), (result) =>
             {
                 var offerResult = new OfferResult
                 {
@@ -230,9 +244,9 @@ namespace Metica.Unity
             });
         }
 
-        private static IEnumerator GetOffersAsDictionaryCoroutine(String[] placements, MeticaSdkDelegate<Dictionary<string, List<Offer>>> responseCallback, Dictionary<string, object> userProperties = null, DeviceInfo deviceInfo = null)
+        private static IEnumerator GetOffersAsDictionaryCoroutine(String[] placements, MeticaSdkDelegate<Dictionary<string, List<Offer>>> responseCallback, Dictionary<string, object> userProperties = null)
         {
-            yield return RunAsyncTaskCoroutine(() => SDK.GetOffersAsync(placements, userProperties, deviceInfo), (result) =>
+            yield return RunAsyncTaskCoroutine(() => SDK.GetOffersAsync(placements, userProperties), (result) =>
             {
                 responseCallback?.Invoke(new SdkResultImpl<Dictionary<string, List<Offer>>>().WithResult(result.Result.placements));
             });


### PR DESCRIPTION
**We now want the `DeviceInfo` to ALWAYS be collected automatically** so we are deprecating all public methods that take a `DeviceInfo` as parameter since it is now always generated by the SDK via `IDeviceInfoProvider`.

This is related to the <_adding more auto-collected fields_> mission.

[See card for more info](https://linear.app/metica/issue/MET-2975/deprecate-sdk-calls-that-accept-a-deviceinfo)