### PR TITLE
[MET-3187] Break `MeticaSdk` dependency on `UnityEngine`

### DIFF
--- a/Runtime/SDK/MeticaSdk.cs
+++ b/Runtime/SDK/MeticaSdk.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Metica.Core;
 using Metica.Network;
 using Metica.SDK.Model;
-using UnityEngine;
 
 namespace Metica.SDK
 {
@@ -54,9 +53,11 @@ namespace Metica.SDK
 
         #endregion Fields
 
-        // Ensures static fields are reset when entering Play Mode without Domain Reload
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
-        private static void ResetStaticFields()
+        /// <summary>
+        ///  Utility, (Unity specific) method that should not be used directly.
+        /// Resets static properties to null.
+        /// </summary>
+        public static void ResetStaticFields()
         {
             CurrentUserId = null;
             ApiKey = null;

--- a/Runtime/Unity/DeviceInfoProvider.cs
+++ b/Runtime/Unity/DeviceInfoProvider.cs
@@ -11,7 +11,7 @@ namespace Metica.Unity
     /// Unity implementation of <see cref="IDeviceInfoProvider"/>.
     /// The obtained information is cached so it is collected <b>once</b> and remains unchanged for the whole application lifetime.
     /// </summary>
-    public class DeviceInfoProvider : IDeviceInfoProvider
+    internal class DeviceInfoProvider : IDeviceInfoProvider
     {
         private readonly Lazy<DeviceInfo> _cachedDeviceInfo = new Lazy<DeviceInfo>(() => CreateDeviceInfo());
 

--- a/Runtime/Unity/MeticaUnityHandlers.cs
+++ b/Runtime/Unity/MeticaUnityHandlers.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+using Metica.SDK;
+
+namespace Metica.Unity
+{
+    public static class MeticaUnityHandlers
+    {
+        /// <summary>
+        ///  Ensures static fields are reset when entering Play Mode without Domain Reload
+        /// </summary>
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void ResetStaticFields() => MeticaSdk.ResetStaticFields();
+    }
+}

--- a/Runtime/Unity/MeticaUnityHandlers.cs.meta
+++ b/Runtime/Unity/MeticaUnityHandlers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9f62ccf3dac6d2478966cf5f4cf3d404
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
[MET-3187](https://linear.app/metica/issue/MET-3187/break-meticasdk-dependency-on-unityengine)

Break `MeticaSdk` dependency on `UnityEngine`
that was only due to the need for a `RuntimeInitializeOnLoadMethod` attribute. This has been moved to a separate static class that lives in `Metica.Unity`.
