### PR TITLE
[MET-3510] `SystemInfo` managed via `IDeviceInfoProvider` and `deviceUniqueId`

### DIFF
--- a/Runtime/SDK/ConfigManager.cs
+++ b/Runtime/SDK/ConfigManager.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 using UnityEngine.Scripting; // TODO : MET-3509 : break dependency from UnityEngine
-using SystemInfo = UnityEngine.Device.SystemInfo;
 
 using Metica.Core;
 using Metica.Network;
@@ -60,9 +59,9 @@ namespace Metica.SDK
 
                 // Inject the additional device information using the SystemInfo class
                 // This will add the keys or update them if they already exist.
-                finalUserData["deviceType"] = SystemInfo.deviceType.ToString();
-                finalUserData["osVersion"] = SystemInfo.operatingSystem;
-                finalUserData["deviceModel"] = SystemInfo.deviceModel;
+                finalUserData["deviceType"] = _deviceInfoProvider.deviceType.ToString();
+                finalUserData["osVersion"] = _deviceInfoProvider.operatingSystem;
+                finalUserData["deviceModel"] = _deviceInfoProvider.deviceModel;
 
                 var requestBody = new Dictionary<string, object>
                 {

--- a/Runtime/SDK/IDeviceInfoProvider.cs
+++ b/Runtime/SDK/IDeviceInfoProvider.cs
@@ -2,12 +2,31 @@ using Metica.SDK.Model;
 
 namespace Metica.SDK
 {
+    /// <summary>
+    /// Provider of <see cref="DeviceInfo"/> structure as defined in Metica API schema
+    /// and other information like <see cref="deviceType"/> and <see cref="operatingSystem"/>.
+    /// </summary>
     public interface IDeviceInfoProvider
     {
+        /// <summary>
+        /// Gets the <see cref="DeviceInfo"/> structure as defined in the Metica API schema.
+        /// </summary>
+        /// <returns><see cref="DeviceInfo"/></returns>
+        /// <remarks>An instance of <see cref="DeviceInfo"/> is created lazily (when requested the first time)
+        /// and cached for the whole application lifetime.</remarks>
         DeviceInfo GetDeviceInfo();
 
+        /// <summary>
+        /// Gets the device type.
+        /// </summary>
         public string deviceType { get; }
+        /// <summary>
+        /// Gets the device's operating system.
+        /// </summary>
         public string operatingSystem { get; }
+        /// <summary>
+        /// Gets the device model.
+        /// </summary>
         public string deviceModel { get; }
     }
 }

--- a/Runtime/SDK/IDeviceInfoProvider.cs
+++ b/Runtime/SDK/IDeviceInfoProvider.cs
@@ -19,14 +19,18 @@ namespace Metica.SDK
         /// <summary>
         /// Gets the device type.
         /// </summary>
-        public string deviceType { get; }
+        string deviceType { get; }
+        /// <summary>
+        /// Gets a hashed device unique identifier.
+        /// </summary>
+        string deviceUniqueId { get; }
         /// <summary>
         /// Gets the device's operating system.
         /// </summary>
-        public string operatingSystem { get; }
+        string operatingSystem { get; }
         /// <summary>
         /// Gets the device model.
         /// </summary>
-        public string deviceModel { get; }
+        string deviceModel { get; }
     }
 }

--- a/Runtime/SDK/IDeviceInfoProvider.cs
+++ b/Runtime/SDK/IDeviceInfoProvider.cs
@@ -5,5 +5,9 @@ namespace Metica.SDK
     public interface IDeviceInfoProvider
     {
         DeviceInfo GetDeviceInfo();
+
+        public string deviceType { get; }
+        public string operatingSystem { get; }
+        public string deviceModel { get; }
     }
 }

--- a/Runtime/SDK/OfferManager.cs
+++ b/Runtime/SDK/OfferManager.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Metica.Core;
 using Metica.Network;

--- a/Runtime/Unity/DeviceInfoProvider.cs
+++ b/Runtime/Unity/DeviceInfoProvider.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Threading;
+using System.Security.Cryptography;
+using System.Text;
+
 using UnityEngine;
 
 using Metica.SDK;
@@ -14,12 +17,21 @@ namespace Metica.Unity
     internal class DeviceInfoProvider : IDeviceInfoProvider
     {
         private readonly Lazy<DeviceInfo> _cachedDeviceInfo = new Lazy<DeviceInfo>(() => CreateDeviceInfo());
+        private readonly Lazy<string> _hashedDeviceId = new Lazy<string>(() =>
+        {
+            using var sha = SHA256.Create();
+            var bytes = Encoding.UTF8.GetBytes(SystemInfo.deviceUniqueIdentifier);
+            return Convert.ToBase64String(sha.ComputeHash(bytes));
+        });
+
         /// <inheritdoc/>
-        public string deviceType { get => SystemInfo.deviceType.ToString(); }
+        public string deviceType => SystemInfo.deviceType.ToString();
         /// <inheritdoc/>
-        public string operatingSystem { get => SystemInfo.operatingSystem; }
+        public string deviceUniqueId => _hashedDeviceId.Value;
         /// <inheritdoc/>
-        public string deviceModel { get => SystemInfo.deviceModel; }
+        public string operatingSystem => SystemInfo.operatingSystem;
+        /// <inheritdoc/>
+        public string deviceModel => SystemInfo.deviceModel;
 
         /// <inheritdoc/>
         public DeviceInfo GetDeviceInfo() => _cachedDeviceInfo.Value;

--- a/Runtime/Unity/DeviceInfoProvider.cs
+++ b/Runtime/Unity/DeviceInfoProvider.cs
@@ -14,6 +14,9 @@ namespace Metica.Unity
     internal class DeviceInfoProvider : IDeviceInfoProvider
     {
         private readonly Lazy<DeviceInfo> _cachedDeviceInfo = new Lazy<DeviceInfo>(() => CreateDeviceInfo());
+        public string deviceType { get => SystemInfo.deviceType.ToString(); }
+        public string operatingSystem { get => SystemInfo.operatingSystem; }
+        public string deviceModel { get => SystemInfo.deviceModel; }
 
         public DeviceInfo GetDeviceInfo() => _cachedDeviceInfo.Value;
 

--- a/Runtime/Unity/DeviceInfoProvider.cs
+++ b/Runtime/Unity/DeviceInfoProvider.cs
@@ -14,10 +14,14 @@ namespace Metica.Unity
     internal class DeviceInfoProvider : IDeviceInfoProvider
     {
         private readonly Lazy<DeviceInfo> _cachedDeviceInfo = new Lazy<DeviceInfo>(() => CreateDeviceInfo());
+        /// <inheritdoc/>
         public string deviceType { get => SystemInfo.deviceType.ToString(); }
+        /// <inheritdoc/>
         public string operatingSystem { get => SystemInfo.operatingSystem; }
+        /// <inheritdoc/>
         public string deviceModel { get => SystemInfo.deviceModel; }
 
+        /// <inheritdoc/>
         public DeviceInfo GetDeviceInfo() => _cachedDeviceInfo.Value;
 
         private static DeviceInfo CreateDeviceInfo()

--- a/Runtime/Unity/DeviceInfoProvider.cs
+++ b/Runtime/Unity/DeviceInfoProvider.cs
@@ -17,7 +17,7 @@ namespace Metica.Unity
     internal class DeviceInfoProvider : IDeviceInfoProvider
     {
         private readonly Lazy<DeviceInfo> _cachedDeviceInfo = new Lazy<DeviceInfo>(() => CreateDeviceInfo());
-        private readonly Lazy<string> _hashedDeviceId = new Lazy<string>(() =>
+        private readonly Lazy<string> _cachedHashedDeviceId = new Lazy<string>(() =>
         {
             using var sha = SHA256.Create();
             var bytes = Encoding.UTF8.GetBytes(SystemInfo.deviceUniqueIdentifier);
@@ -27,7 +27,7 @@ namespace Metica.Unity
         /// <inheritdoc/>
         public string deviceType => SystemInfo.deviceType.ToString();
         /// <inheritdoc/>
-        public string deviceUniqueId => _hashedDeviceId.Value;
+        public string deviceUniqueId => _cachedHashedDeviceId.Value;
         /// <inheritdoc/>
         public string operatingSystem => SystemInfo.operatingSystem;
         /// <inheritdoc/>


### PR DESCRIPTION
Move Unity specific `SystemInfo` properties to `DeviceInfoProvider` so we have one less SDK => Unity dependency in `ConfigManager` and we can easily access those info via interface `IDeviceInfoProvider`.
Also adds `IDeviceInfoProvider.deviceUniqueId` which provides a hashed device UID.