### PR TITLE
[MET-3509] Restore `ConfigManager` independency from Unity

### DIFF
--- a/Runtime/SDK/ConfigManager.cs
+++ b/Runtime/SDK/ConfigManager.cs
@@ -2,21 +2,17 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 
-using UnityEngine.Scripting; // TODO : MET-3509 : break dependency from UnityEngine
-
 using Metica.Core;
 using Metica.Network;
 using Metica.SDK.Model;
 
 namespace Metica.SDK
 {
-    [Preserve]
     [System.Serializable]
     public class ConfigResult : IMeticaHttpResult
     {
         // TODO : ideally fields should be readonly or with private setter
 
-        [Preserve]
         [JsonExtensionData] // Needed when we want the root (anonymous dictionary in this case) to go in a specific field
         public Dictionary<string, object> Configs { get; set; }
 

--- a/Runtime/Unity/link.xml
+++ b/Runtime/Unity/link.xml
@@ -1,0 +1,5 @@
+<linker>
+  <assembly fullname="Metica.SDK">
+    <type fullname="Metica.SDK.ConfigResult" preserve="all"/>
+  </assembly>
+</linker>

--- a/Runtime/Unity/link.xml.meta
+++ b/Runtime/Unity/link.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 743c235b0f9482ebd85c811ec4940b5d
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Use `link.xml` for preservation of fields/classes during IL2CPP code stripping.
This replaces the "[Preserve]" attribute, defined in `UnityEngine.Scripting`.

`ConfigManager` independency from Unity is restored and thanks to @antonurankar-moloco we proptly tested that this solution effectively works and allows preserving the `ConfigResult` class without the runtime error that was observed before adding the `[Preserve]` attributes.