### PR TITLE
OfferManager : break dependency from UnityEngine

### DIFF
--- a/Runtime/SDK/OfferManager.cs
+++ b/Runtime/SDK/OfferManager.cs
@@ -6,15 +6,12 @@ using Metica.Core;
 using Metica.Network;
 using Metica.SDK.Model;
 using Newtonsoft.Json;
-using UnityEngine.Scripting;
 
 namespace Metica.SDK
 {
-    [Preserve]
-    [System.Serializable]
+    [Serializable]
     public class OfferResult : IMeticaHttpResult
     {
-        [Preserve]
         [JsonProperty("placements")]
         public Dictionary<string, List<Offer>> placements { get; set; }
 

--- a/Runtime/Unity/link.xml
+++ b/Runtime/Unity/link.xml
@@ -1,5 +1,6 @@
 <linker>
   <assembly fullname="Metica.SDK">
     <type fullname="Metica.SDK.ConfigResult" preserve="all"/>
+    <type fullname="Metica.SDK.OfferResult" preserve="all"/>
   </assembly>
 </linker>


### PR DESCRIPTION
Use link.xml to replace the need for `Unity.Scripting.PreserveAttribute` in `OfferManager`.