### PR TITLE
[Bugfix/MET-4131] device info provider fix

### DIFF
--- a/Runtime/Unity/DeviceInfoProvider.cs
+++ b/Runtime/Unity/DeviceInfoProvider.cs
@@ -14,7 +14,7 @@ namespace Metica.Unity
     /// Unity implementation of <see cref="IDeviceInfoProvider"/>.
     /// The obtained information is cached so it is collected <b>once</b> and remains unchanged for the whole application lifetime.
     /// </summary>
-    internal class DeviceInfoProvider : IDeviceInfoProvider
+    public class DeviceInfoProvider : IDeviceInfoProvider
     {
         private readonly Lazy<DeviceInfo> _cachedDeviceInfo = new Lazy<DeviceInfo>(() => CreateDeviceInfo());
         private readonly Lazy<string> _cachedHashedDeviceId = new Lazy<string>(() =>


### PR DESCRIPTION
## [MET-4131](https://linear.app/metica/issue/MET-4131/fix-deviceinfoprovider-access-modifier)

It has been brought up that `DeviceInfoProvider` being set to `internal` it is an obstacle for all use cases that do a custom initialisation without passing through the `MeticaSdk` prefab.

This PR fixes it by setting the class access modifier back to `public`.