### PR TITLE
Improve initialization to enable custom C# workfllows

### DIFF
--- a/Runtime/SDK/MeticaSdk.cs
+++ b/Runtime/SDK/MeticaSdk.cs
@@ -7,7 +7,7 @@ using Metica.SDK.Model;
 
 namespace Metica.SDK
 {
-    public interface IMeticaSdk
+    public interface IMeticaSdk : IAsyncDisposable
     {
         Task<ConfigResult> GetConfigsAsync(List<string> configKeys = null, Dictionary<string, object> userData = null);
         [Obsolete]
@@ -30,7 +30,7 @@ namespace Metica.SDK
         void RequestDispatchEvents();
     }
 
-    public class MeticaSdk : IMeticaSdk, IAsyncDisposable
+    public class MeticaSdk : IMeticaSdk
     {
         #region Fields
 

--- a/Runtime/Unity/MeticaUnitySdk.cs
+++ b/Runtime/Unity/MeticaUnitySdk.cs
@@ -17,14 +17,18 @@ namespace Metica.Unity
 
         private void Awake()
         {
-            // Register implementations before anything else. These are Unity implementations.
-            Registry.Register<IDeviceInfoProvider>(new DeviceInfoProvider());
-            Registry.Register<ILog>(new MeticaLogger(_sdkConfigProvider.SdkConfig.logLevel));
-
+            RegisterUnityServices(_sdkConfigProvider.SdkConfig);
             // Initialize Metica SDK.
             _meticaSdk = new MeticaSdk(_sdkConfigProvider.SdkConfig);
 
             DontDestroyOnLoad(this);
+        }
+
+        public static void RegisterUnityServices(SdkConfig sdkConfig)
+        {
+            // Register implementations before anything else. These are Unity implementations.
+            Registry.Register<IDeviceInfoProvider>(new DeviceInfoProvider());
+            Registry.Register<ILog>(new MeticaLogger(sdkConfig.logLevel));
         }
 
         private async void OnApplicationFocus(bool focus)


### PR DESCRIPTION
[MET-4270](https://linear.app/metica/issue/MET-4270/improve-unity-sdk-initialization-to-remove-obstacles-to-monobehaviour)

- Move the `IAsyncDisposable` up to `IMeticaSdk` rather than directly in `MeticaSdk`
- In `MeticaUnitySdk`, wrap the Unity services registration into a static call so it can be called in code flows that want to remain "`MonoBehaviour` free"