### PR TITLE
Initialize CurrentUserId to null, ignore obsolete `initialUserId` value.

### DIFF
--- a/Runtime/SDK/MeticaSdk.cs
+++ b/Runtime/SDK/MeticaSdk.cs
@@ -77,7 +77,7 @@ namespace Metica.SDK
         {
             _sdkConfig = config;
 
-            if(string.IsNullOrEmpty(_sdkConfig.apiKey) || string.IsNullOrEmpty(_sdkConfig.initialUserId) || string.IsNullOrEmpty(_sdkConfig.appId) || string.IsNullOrEmpty(config.baseEndpoint))
+            if(string.IsNullOrEmpty(_sdkConfig.apiKey) || string.IsNullOrEmpty(_sdkConfig.appId) || string.IsNullOrEmpty(config.baseEndpoint))
             {
                 Log.Error(() => "The given SDK configuration is not valid. Please make sure all fields are filled.");
                 return;
@@ -102,7 +102,7 @@ namespace Metica.SDK
             // Initialize an EventManager with _offerManager as IMeticaAttributesProvider
             _eventManager = new EventManager(_http, $"{Config.baseEndpoint}/ingest/v1/events", _offerManager, config.eventsLogDispatchMaxQueueSize);
             // Set the current (mutable) CurrentUserId with the initial value given in the configuration
-            CurrentUserId = null; // Config.initialUserId;
+            CurrentUserId = null;
             ApiKey = Config.apiKey;
             AppId = Config.appId;
             BaseEndpoint = Config.baseEndpoint;

--- a/Runtime/SDK/SdkConfig.cs
+++ b/Runtime/SDK/SdkConfig.cs
@@ -5,7 +5,6 @@ namespace Metica.SDK
     {
         public string apiKey;
         public string appId;
-        public string initialUserId;
 
         private const string DefaultEndpoint = "https://api-gateway.prod-eu.metica.com";
 
@@ -79,7 +78,6 @@ namespace Metica.SDK
                 // Parameters for MeticaContext
                 apiKey = string.Empty,
                 appId = string.Empty,
-                initialUserId = string.Empty,
                 // - - - - - - - - - -
                 baseEndpoint = DefaultEndpoint,
                 //maxDisplayLogEntries = 256,


### PR DESCRIPTION
# [MET-4218](https://linear.app/metica/issue/MET-4218/add-function-to-generate-userid-in-android)

Initializes the `currentUserId` field as null by default.
`initialUserId` removed.
Allows `userId` to be passed to android-sdk with a value or OR null. Passing empty or null has the same effect.

This goes hand in hand with [metica-android-sdk PR#77](https://github.com/meticalabs/metica-android-sdk/pull/77/files)