### PR TITLE
MET-4365: Refactor MeticaAds initialization to return detailed result status an…

### DIFF
--- a/Editor/MeticaAdsDependencies.xml
+++ b/Editor/MeticaAdsDependencies.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <dependencies>
     <androidPackages>
-        <androidPackage spec="com.metica:metica-sdk:1.13.3" />
+        <androidPackage spec="com.metica:metica-sdk:1.13.4" />
     </androidPackages>
 </dependencies>

--- a/Runtime/ADS/MeticaAds.cs
+++ b/Runtime/ADS/MeticaAds.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Metica.SDK;
 
 // ReSharper disable once CheckNamespace
-namespace Metica.ADS 
+namespace Metica.ADS
 {
     public static class MeticaAds
     {   
@@ -52,8 +52,22 @@ namespace Metica.ADS
 
         public static async Task<bool> InitializeAsync(MeticaConfiguration configuration)
         {
-            return await PlatformDelegate.InitializeAsync(MeticaSdk.ApiKey, MeticaSdk.AppId, MeticaSdk.CurrentUserId, MeticaSdk.Version, MeticaSdk.BaseEndpoint, configuration);
+            var result = await InitializeWithResultAsync(configuration);
+            return result.IsMeticaAdsEnabled;
         }
+
+        public static async Task<MeticaAdsInitializationResult> InitializeWithResultAsync(MeticaConfiguration configuration)
+        {
+            return await PlatformDelegate.InitializeAsync(
+                MeticaSdk.ApiKey,
+                MeticaSdk.AppId,
+                MeticaSdk.CurrentUserId,
+                MeticaSdk.Version,
+                MeticaSdk.BaseEndpoint,
+                configuration
+            );
+        }
+
         public static void SetLogEnabled(bool logEnabled) 
         {
             PlatformDelegate.SetLogEnabled(logEnabled);

--- a/Runtime/ADS/MeticaAdsAssignmentStatus.cs
+++ b/Runtime/ADS/MeticaAdsAssignmentStatus.cs
@@ -1,0 +1,9 @@
+namespace Metica.ADS
+{
+    public enum MeticaAdsAssignmentStatus
+    {
+        Normal,
+        Holdout,
+        HoldoutDueToError,
+    }
+}

--- a/Runtime/ADS/MeticaAdsAssignmentStatus.cs.meta
+++ b/Runtime/ADS/MeticaAdsAssignmentStatus.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 34f20d96a1fc408ba61824863aaff50b
+timeCreated: 1758915016

--- a/Runtime/ADS/MeticaAdsInitializationResult.cs
+++ b/Runtime/ADS/MeticaAdsInitializationResult.cs
@@ -1,0 +1,27 @@
+namespace Metica.ADS
+{
+    public class MeticaAdsInitializationResult
+    {
+        public MeticaAdsInitializationResult(MeticaAdsAssignmentStatus status)
+        {
+            Status = status;
+        }
+
+        public bool IsMeticaAdsEnabled
+        {
+            get
+            {
+                // Check if the status indicates that Metica Ads should be enabled
+                if (Status == MeticaAdsAssignmentStatus.Normal)
+                {
+                    return true;
+                }
+
+                // For all other status values (i.e. Holdout and HoldoutDueToError), Metica Ads should be disabled
+                return false;
+            }
+        }
+
+        public MeticaAdsAssignmentStatus Status { get; }
+    }
+}

--- a/Runtime/ADS/MeticaAdsInitializationResult.cs.meta
+++ b/Runtime/ADS/MeticaAdsInitializationResult.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 66f2d9b99af0448cb36bb46c7d135efe
+timeCreated: 1758915051

--- a/Runtime/ADS/Platform/Android/AndroidDelegate.cs
+++ b/Runtime/ADS/Platform/Android/AndroidDelegate.cs
@@ -53,10 +53,10 @@ internal class AndroidDelegate : PlatformDelegate
         _unityBridgeAndroidClass.CallStatic("setLogEnabled", logEnabled);
     }
 
-    public Task<bool> InitializeAsync(string apiKey, string appId, string userId, string version, string baseEndpoint,
+    public Task<MeticaAdsInitializationResult> InitializeAsync(string apiKey, string appId, string userId, string version, string baseEndpoint,
         MeticaConfiguration configuration)
     {
-        var tcs = new TaskCompletionSource<bool>();
+        var tcs = new TaskCompletionSource<MeticaAdsInitializationResult>();
 
         var callback = new InitializeCallbackProxy(tcs);
         _unityBridgeAndroidClass.CallStatic("initialize", apiKey, appId, userId, callback);

--- a/Runtime/ADS/Platform/Android/InitializeCallbackProxy.cs
+++ b/Runtime/ADS/Platform/Android/InitializeCallbackProxy.cs
@@ -10,9 +10,9 @@ namespace Metica.ADS
 public class InitializeCallbackProxy : AndroidJavaProxy
 {
     private const string TAG = MeticaAds.TAG;
-    private readonly TaskCompletionSource<bool> _tcs;
+    private readonly TaskCompletionSource<MeticaAdsInitializationResult> _tcs;
 
-    public InitializeCallbackProxy(TaskCompletionSource<bool> tcs)
+    public InitializeCallbackProxy(TaskCompletionSource<MeticaAdsInitializationResult> tcs)
         : base("com.metica.MeticaInitCallback")
     {
         Debug.Log($"{TAG} MeticaAdsInitCallback created");
@@ -23,14 +23,27 @@ public class InitializeCallbackProxy : AndroidJavaProxy
     public void onInitialized(bool adsEnabled)
     {
         Debug.Log($"{TAG} onInitialized: {adsEnabled}");
-        _tcs.SetResult(adsEnabled);
+        if (adsEnabled)
+        {
+            _tcs.SetResult(
+                new MeticaAdsInitializationResult(MeticaAdsAssignmentStatus.Normal)
+            );
+        }
+        else
+        {
+            _tcs.SetResult(
+                new MeticaAdsInitializationResult(MeticaAdsAssignmentStatus.Holdout)
+            );
+        }
     }
 
     // Called from Android when initialization fails
     public void onFailed(string reason)
     {
         Debug.Log($"{TAG} onFailed: {reason}");
-        _tcs.SetResult(false);
+        _tcs.SetResult(
+            new MeticaAdsInitializationResult(MeticaAdsAssignmentStatus.HoldoutDueToError)
+        );
     }
 }
 }

--- a/Runtime/ADS/Platform/IOS/IOSDelegate.cs
+++ b/Runtime/ADS/Platform/IOS/IOSDelegate.cs
@@ -56,11 +56,13 @@ internal class IOSDelegate : PlatformDelegate
     {
     }
 
-    public Task<bool> InitializeAsync(string apiKey, string appId, string userId, string version, string baseEndpoint,
+    public Task<MeticaAdsInitializationResult> InitializeAsync(string apiKey, string appId, string userId, string version, string baseEndpoint,
         MeticaConfiguration configuration)
     {
-        var tcs = new TaskCompletionSource<bool>();
-        tcs.SetResult(false);
+        var tcs = new TaskCompletionSource<MeticaAdsInitializationResult>();
+        tcs.SetResult(
+            new MeticaAdsInitializationResult(MeticaAdsAssignmentStatus.HoldoutDueToError)
+        );
         return tcs.Task;
     }
 

--- a/Runtime/ADS/Platform/PlatformDelegate.cs
+++ b/Runtime/ADS/Platform/PlatformDelegate.cs
@@ -32,8 +32,14 @@ internal interface PlatformDelegate
     public event Action<MeticaAd> RewardedAdRewarded;
     public event Action<MeticaAd> RewardedAdRevenuePaid;
 
-    Task<bool> InitializeAsync(string apiKey, string appId, string userId, string version, string baseEndpoint,
-        MeticaConfiguration configuration);
+    Task<MeticaAdsInitializationResult> InitializeAsync(
+        string apiKey,
+        string appId,
+        string userId,
+        string version,
+        string baseEndpoint,
+        MeticaConfiguration configuration
+    );
     void SetLogEnabled(bool logEnabled);
             
     // Banner methods

--- a/Runtime/ADS/Platform/UnityPlayer/UnityPlayerDelegate.cs
+++ b/Runtime/ADS/Platform/UnityPlayer/UnityPlayerDelegate.cs
@@ -28,11 +28,15 @@ internal class UnityPlayerDelegate : PlatformDelegate
     public event Action<MeticaAd> RewardedAdRewarded;
     public event Action<MeticaAd> RewardedAdRevenuePaid;
 
-    public Task<bool> InitializeAsync(string apiKey, string appId, string userId, string version, string baseEndpoint,
+    public Task<MeticaAdsInitializationResult> InitializeAsync(string apiKey, string appId, string userId, string version, string baseEndpoint,
         MeticaConfiguration meticaConfiguration)
     {
-        Debug.Log("[MeticaAds Unity] Mock initialization - always returns false");
-        return Task.FromResult(false);
+        Debug.Log("[MeticaAds Unity] Mock initialization - always returns HoldoutDueToError");
+        var tcs = new TaskCompletionSource<MeticaAdsInitializationResult>();
+        tcs.SetResult(
+            new MeticaAdsInitializationResult(MeticaAdsAssignmentStatus.HoldoutDueToError)
+        );
+        return tcs.Task;
     }
 
     public void SetLogEnabled(bool logEnabled)

--- a/Runtime/SDK/MeticaSdk.cs
+++ b/Runtime/SDK/MeticaSdk.cs
@@ -36,7 +36,7 @@ namespace Metica.SDK
 
         public static IMeticaSdk SDK {  get => Registry.Resolve<IMeticaSdk>(); }
 
-        public static string Version { get => "1.13.3"; }
+        public static string Version { get => "1.13.4"; }
 
         public static string CurrentUserId {  get; set; }
         public static string ApiKey { get; private set; }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.metica.unity",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "displayName": "Metica Unity SDK",
   "description": "Unity components to interface with the Metica offers platform.",
   "unity": "2020.3",


### PR DESCRIPTION
This pull request updates the Metica Unity SDK to version 1.13.4 and refactors the ads initialization flow to provide more detailed status information about ad assignment and initialization results. The main changes introduce a new result type for initialization, update interfaces and platform delegates, and add new enums to represent assignment status.